### PR TITLE
Secure gRPC auth/authz for streaming and add missing RPC permissions

### DIFF
--- a/file-engine/internal/auth/grpc_interceptor.go
+++ b/file-engine/internal/auth/grpc_interceptor.go
@@ -1,36 +1,70 @@
 package auth
 
 import (
-    "context"
+	"context"
 
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/metadata"
-    "google.golang.org/grpc/status"
-    "google.golang.org/grpc/codes"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // GRPCAuthInterceptor extracts `authorization` metadata and stores AuthContext in context.
 func GRPCAuthInterceptor(verifier *JWTVerifier) grpc.UnaryServerInterceptor {
-    return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-        md, ok := metadata.FromIncomingContext(ctx)
-        if !ok {
-            return nil, status.Error(codes.Unauthenticated, "missing metadata")
-        }
-        vals := md.Get("authorization")
-        if len(vals) == 0 {
-            // Some gateways use "Authorization"
-            vals = md.Get("Authorization")
-        }
-        if len(vals) == 0 {
-            return nil, status.Error(codes.Unauthenticated, "missing authorization")
-        }
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing metadata")
+		}
+		vals := md.Get("authorization")
+		if len(vals) == 0 {
+			// Some gateways use "Authorization"
+			vals = md.Get("Authorization")
+		}
+		if len(vals) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "missing authorization")
+		}
 
-        a, err := verifier.ParseAuthContext(vals[0])
-        if err != nil {
-            return nil, status.Error(codes.Unauthenticated, "invalid token")
-        }
+		a, err := verifier.ParseAuthContext(vals[0])
+		if err != nil {
+			return nil, status.Error(codes.Unauthenticated, "invalid token")
+		}
 
-        ctx = WithAuthContext(ctx, a)
-        return handler(ctx, req)
-    }
+		ctx = WithAuthContext(ctx, a)
+		return handler(ctx, req)
+	}
+}
+
+type wrappedServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedServerStream) Context() context.Context {
+	return w.ctx
+}
+
+// GRPCStreamAuthInterceptor extracts `authorization` metadata and stores AuthContext in stream context.
+func GRPCStreamAuthInterceptor(verifier *JWTVerifier) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		md, ok := metadata.FromIncomingContext(stream.Context())
+		if !ok {
+			return status.Error(codes.Unauthenticated, "missing metadata")
+		}
+		vals := md.Get("authorization")
+		if len(vals) == 0 {
+			vals = md.Get("Authorization")
+		}
+		if len(vals) == 0 {
+			return status.Error(codes.Unauthenticated, "missing authorization")
+		}
+
+		a, err := verifier.ParseAuthContext(vals[0])
+		if err != nil {
+			return status.Error(codes.Unauthenticated, "invalid token")
+		}
+
+		ctx := WithAuthContext(stream.Context(), a)
+		return handler(srv, &wrappedServerStream{ServerStream: stream, ctx: ctx})
+	}
 }

--- a/file-engine/internal/authz/grpc_authz_interceptor.go
+++ b/file-engine/internal/authz/grpc_authz_interceptor.go
@@ -1,35 +1,82 @@
 package authz
 
 import (
-    "context"
+	"context"
 
-    "github.com/example/file-engine/internal/auth"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/codes"
-    "google.golang.org/grpc/status"
+	"github.com/example/file-engine/internal/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func GRPCAuthZInterceptor(store auth.ACLStore) grpc.UnaryServerInterceptor {
-    return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-        perm, ok := MethodPermission[info.FullMethod]
-        if !ok {
-            return nil, status.Error(codes.PermissionDenied, "no permission mapping for method")
-        }
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		perm, ok := MethodPermission[info.FullMethod]
+		if !ok {
+			return nil, status.Error(codes.PermissionDenied, "no permission mapping for method")
+		}
 
-        a, ok := auth.FromContext(ctx)
-        if !ok {
-            return nil, status.Error(codes.Unauthenticated, "missing auth context")
-        }
+		a, ok := auth.FromContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing auth context")
+		}
 
-        path, err := ExtractPath(req)
-        if err != nil {
-            return nil, status.Error(codes.InvalidArgument, "cannot extract path")
-        }
+		path, err := ExtractPath(req)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "cannot extract path")
+		}
 
-        if !auth.CanAccess(a, path, perm, store) {
-            return nil, status.Error(codes.PermissionDenied, "access denied")
-        }
+		if !auth.CanAccess(a, path, perm, store) {
+			return nil, status.Error(codes.PermissionDenied, "access denied")
+		}
 
-        return handler(ctx, req)
-    }
+		return handler(ctx, req)
+	}
+}
+
+type authzServerStream struct {
+	grpc.ServerStream
+	authCtx auth.AuthContext
+	perm    auth.Permission
+	store   auth.ACLStore
+	checked bool
+}
+
+func (s *authzServerStream) RecvMsg(m any) error {
+	if err := s.ServerStream.RecvMsg(m); err != nil {
+		return err
+	}
+	if !s.checked {
+		s.checked = true
+		path, err := ExtractPath(m)
+		if err != nil {
+			return status.Error(codes.InvalidArgument, "cannot extract path")
+		}
+		if !auth.CanAccess(s.authCtx, path, s.perm, s.store) {
+			return status.Error(codes.PermissionDenied, "access denied")
+		}
+	}
+	return nil
+}
+
+func GRPCAuthZStreamInterceptor(store auth.ACLStore) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		perm, ok := MethodPermission[info.FullMethod]
+		if !ok {
+			return status.Error(codes.PermissionDenied, "no permission mapping for method")
+		}
+
+		a, ok := auth.FromContext(stream.Context())
+		if !ok {
+			return status.Error(codes.Unauthenticated, "missing auth context")
+		}
+
+		wrapped := &authzServerStream{
+			ServerStream: stream,
+			authCtx:      a,
+			perm:         perm,
+			store:        store,
+		}
+		return handler(srv, wrapped)
+	}
 }

--- a/file-engine/internal/authz/method_map.go
+++ b/file-engine/internal/authz/method_map.go
@@ -4,8 +4,12 @@ import "github.com/example/file-engine/internal/auth"
 
 // MethodPermission maps gRPC full method name -> required permission.
 var MethodPermission = map[string]auth.Permission{
-    "/fileengine.FileEngine/CreateFolder":   auth.PermWrite,
-    "/fileengine.FileEngine/ListObjects":    auth.PermList,
-    "/fileengine.FileEngine/UploadObject":   auth.PermWrite,
-    "/fileengine.FileEngine/DownloadObject": auth.PermRead,
+	"/fileengine.FileEngine/CreateFolder":   auth.PermWrite,
+	"/fileengine.FileEngine/InitiateUpload": auth.PermWrite,
+	"/fileengine.FileEngine/CompleteUpload": auth.PermWrite,
+	"/fileengine.FileEngine/GetTaskStatus":  auth.PermRead,
+	"/fileengine.FileEngine/GetTask":        auth.PermRead,
+	"/fileengine.FileEngine/ListObjects":    auth.PermList,
+	"/fileengine.FileEngine/UploadObject":   auth.PermWrite,
+	"/fileengine.FileEngine/DownloadObject": auth.PermRead,
 }

--- a/file-engine/internal/authz/path_extract.go
+++ b/file-engine/internal/authz/path_extract.go
@@ -1,39 +1,47 @@
 package authz
 
 import (
-    "fmt"
-    "strings"
+	"fmt"
+	"strings"
 
-    pb "github.com/example/file-engine/pkg/generated"
+	pb "github.com/example/file-engine/pkg/generated"
 )
 
 func normalize(p string) string {
-    p = strings.TrimSpace(p)
-    if p == "" {
-        return "/"
-    }
-    if !strings.HasPrefix(p, "/") {
-        p = "/" + p
-    }
-    for strings.Contains(p, "//") {
-        p = strings.ReplaceAll(p, "//", "/")
-    }
-    return p
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
 }
 
 // ExtractPath extracts the relevant path/prefix from an RPC request.
 func ExtractPath(req any) (string, error) {
-    switch r := req.(type) {
-    case *pb.ListObjectsRequest:
-        return normalize(r.Prefix), nil
-    case *pb.UploadObjectRequest:
-        return normalize(r.Path), nil
-    case *pb.DownloadObjectRequest:
-        return normalize(r.Path), nil
-    case *pb.CreateFolderRequest:
-        parent := strings.TrimSuffix(r.ParentPath, "/")
-        return normalize(parent + "/" + r.FolderName), nil
-    default:
-        return "", fmt.Errorf("no path extractor for %T", req)
-    }
+	switch r := req.(type) {
+	case *pb.ListObjectsRequest:
+		return normalize(r.Prefix), nil
+	case *pb.UploadObjectRequest:
+		return normalize(r.Path), nil
+	case *pb.DownloadObjectRequest:
+		return normalize(r.Path), nil
+	case *pb.InitiateUploadRequest:
+		return normalize(r.TargetPath), nil
+	case *pb.CompleteUploadRequest:
+		return "/", nil
+	case *pb.TaskStatusRequest:
+		return "/", nil
+	case *pb.GetTaskRequest:
+		return "/", nil
+	case *pb.CreateFolderRequest:
+		parent := strings.TrimSuffix(r.ParentPath, "/")
+		return normalize(parent + "/" + r.FolderName), nil
+	default:
+		return "", fmt.Errorf("no path extractor for %T", req)
+	}
 }

--- a/file-engine/internal/server/server.go
+++ b/file-engine/internal/server/server.go
@@ -1,107 +1,111 @@
 package server
 
 import (
-    "context"
-    "fmt"
-    "net"
-    "net/http"
-    "time"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
 
-    "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-    "google.golang.org/grpc"
-    "google.golang.org/grpc/credentials/insecure"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
-    pb "github.com/example/file-engine/pkg/generated"
-    "github.com/example/file-engine/internal/auth"
-    "github.com/example/file-engine/internal/authz"
-    "github.com/example/file-engine/internal/logger"
-    "github.com/example/file-engine/internal/storage"
+	"github.com/example/file-engine/internal/auth"
+	"github.com/example/file-engine/internal/authz"
+	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/storage"
+	pb "github.com/example/file-engine/pkg/generated"
 )
 
 type GRPCServer struct {
-    Addr string
-    Log  *logger.Logger
+	Addr string
+	Log  *logger.Logger
 
-    Verifier *auth.JWTVerifier
-    ACLStore  auth.ACLStore
+	Verifier *auth.JWTVerifier
+	ACLStore auth.ACLStore
 
-    Handler pb.FileEngineServer
+	Handler pb.FileEngineServer
 }
 
 type HTTPServer struct {
-    Addr    string
-    GRPCAddr string
-    Log     *logger.Logger
+	Addr     string
+	GRPCAddr string
+	Log      *logger.Logger
 
-    Verifier *auth.JWTVerifier
-    Storage  storage.Storage
+	Verifier *auth.JWTVerifier
+	Storage  storage.Storage
 
-    ACLStore auth.ACLStore
+	ACLStore auth.ACLStore
 }
 
 func NewGRPCServer(addr string, logg *logger.Logger, verifier *auth.JWTVerifier, store auth.ACLStore, handler pb.FileEngineServer) *GRPCServer {
-    return &GRPCServer{
-        Addr: addr, Log: logg,
-        Verifier: verifier, ACLStore: store,
-        Handler: handler,
-    }
+	return &GRPCServer{
+		Addr: addr, Log: logg,
+		Verifier: verifier, ACLStore: store,
+		Handler: handler,
+	}
 }
 
 func NewHTTPServer(addr, grpcAddr string, logg *logger.Logger, verifier *auth.JWTVerifier, st storage.Storage, store auth.ACLStore) *HTTPServer {
-    return &HTTPServer{Addr: addr, GRPCAddr: grpcAddr, Log: logg, Verifier: verifier, Storage: st, ACLStore: store}
+	return &HTTPServer{Addr: addr, GRPCAddr: grpcAddr, Log: logg, Verifier: verifier, Storage: st, ACLStore: store}
 }
 
 func (g *GRPCServer) Start() error {
-    lis, err := net.Listen("tcp", g.Addr)
-    if err != nil {
-        return fmt.Errorf("listen: %w", err)
-    }
+	lis, err := net.Listen("tcp", g.Addr)
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
 
-    srv := grpc.NewServer(
-        grpc.ChainUnaryInterceptor(
-            auth.GRPCAuthInterceptor(g.Verifier),
-            authz.GRPCAuthZInterceptor(g.ACLStore),
-        ),
-    )
+	srv := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			auth.GRPCAuthInterceptor(g.Verifier),
+			authz.GRPCAuthZInterceptor(g.ACLStore),
+		),
+		grpc.ChainStreamInterceptor(
+			auth.GRPCStreamAuthInterceptor(g.Verifier),
+			authz.GRPCAuthZStreamInterceptor(g.ACLStore),
+		),
+	)
 
-    pb.RegisterFileEngineServer(srv, g.Handler)
+	pb.RegisterFileEngineServer(srv, g.Handler)
 
-    g.Log.Infof("gRPC listening on %s", g.Addr)
-    return srv.Serve(lis)
+	g.Log.Infof("gRPC listening on %s", g.Addr)
+	return srv.Serve(lis)
 }
 
 func (h *HTTPServer) Start() error {
-    ctx := context.Background()
+	ctx := context.Background()
 
-    mux := runtime.NewServeMux()
+	mux := runtime.NewServeMux()
 
-    conn, err := grpc.DialContext(
-        ctx,
-        h.GRPCAddr,
-        grpc.WithTransportCredentials(insecure.NewCredentials()),
-    )
-    if err != nil {
-        return fmt.Errorf("dial grpc: %w", err)
-    }
+	conn, err := grpc.DialContext(
+		ctx,
+		h.GRPCAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return fmt.Errorf("dial grpc: %w", err)
+	}
 
-    // Register gateway handlers
-    if err := pb.RegisterFileEngineHandler(ctx, mux, conn); err != nil {
-        return fmt.Errorf("register gateway: %w", err)
-    }
+	// Register gateway handlers
+	if err := pb.RegisterFileEngineHandler(ctx, mux, conn); err != nil {
+		return fmt.Errorf("register gateway: %w", err)
+	}
 
-    root := http.NewServeMux()
-    // Raw download endpoint (REST-friendly): streams bytes directly.
-    root.HandleFunc("/v1/objects:download", h.handleDownload)
+	root := http.NewServeMux()
+	// Raw download endpoint (REST-friendly): streams bytes directly.
+	root.HandleFunc("/v1/objects:download", h.handleDownload)
 
-    // Gateway endpoints (ListObjects, UploadObject, CreateFolder, TaskStatus, etc.)
-    root.Handle("/", auth.HTTPAuthMiddleware(h.Verifier, mux))
+	// Gateway endpoints (ListObjects, UploadObject, CreateFolder, TaskStatus, etc.)
+	root.Handle("/", auth.HTTPAuthMiddleware(h.Verifier, mux))
 
-    srv := &http.Server{
-        Addr:              h.Addr,
-        Handler:           root,
-        ReadHeaderTimeout: 10 * time.Second,
-    }
+	srv := &http.Server{
+		Addr:              h.Addr,
+		Handler:           root,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
-    h.Log.Infof("HTTP listening on %s (proxying to %s)", h.Addr, h.GRPCAddr)
-    return srv.ListenAndServe()
+	h.Log.Infof("HTTP listening on %s (proxying to %s)", h.Addr, h.GRPCAddr)
+	return srv.ListenAndServe()
 }


### PR DESCRIPTION
### Motivation
- Prevent unauthorized access by ensuring streaming gRPC calls run authentication and authorization like unary calls.  
- Avoid breaking existing clients by mapping all defined RPCs to permissions so the authz interceptor does not deny unknown methods.

### Description
- Added `GRPCStreamAuthInterceptor` (with `wrappedServerStream`) in `file-engine/internal/auth/grpc_interceptor.go` to extract and attach auth context for stream RPCs.  
- Added `GRPCAuthZStreamInterceptor` and `authzServerStream` in `file-engine/internal/authz/grpc_authz_interceptor.go` to enforce authorization for streaming RPCs by checking permissions on the first received message.  
- Expanded `MethodPermission` in `file-engine/internal/authz/method_map.go` to include `InitiateUpload`, `CompleteUpload`, `GetTaskStatus`, and `GetTask` alongside existing methods.  
- Extended `ExtractPath` in `file-engine/internal/authz/path_extract.go` to handle `InitiateUploadRequest`, `CompleteUploadRequest`, `TaskStatusRequest`, and `GetTaskRequest` so path-based checks work for upload/task RPCs.  
- Wired stream interceptors into the gRPC server by adding `grpc.ChainStreamInterceptor(...)` in `file-engine/internal/server/server.go`.  
- Reformatted modified files with `gofmt`.

### Testing
- Ran `gofmt -w` on the modified files to ensure formatting (succeeded).  
- No automated unit or integration tests were executed in this change; recommend running `go test ./...` and exercising streaming `DownloadObject` and upload/task RPCs with a gRPC client to validate authentication and authorization behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b59462684832da2d0273d2901901a)