### PR TITLE
fix: unblock snyk go scan by making placeholder files valid Go

### DIFF
--- a/.github/workflows/snyk-scan.yaml
+++ b/.github/workflows/snyk-scan.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22' # Match my project version
+          go-version-file: 'file-engine/go.mod' # Keep CI Go version aligned with module requirement
 
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master

--- a/file-engine/api/proto/file_engine.pb.go
+++ b/file-engine/api/proto/file_engine.pb.go
@@ -1,0 +1,1 @@
+package proto

--- a/file-engine/api/proto/file_engine_grpc.pb.go
+++ b/file-engine/api/proto/file_engine_grpc.pb.go
@@ -1,0 +1,1 @@
+package proto

--- a/file-engine/api/proto/file_engine_grpc_gateway.pb.go
+++ b/file-engine/api/proto/file_engine_grpc_gateway.pb.go
@@ -1,0 +1,1 @@
+package proto

--- a/file-engine/internal/adapters/config/config.go
+++ b/file-engine/internal/adapters/config/config.go
@@ -1,0 +1,1 @@
+package config

--- a/file-engine/internal/adapters/fs/atomic.go
+++ b/file-engine/internal/adapters/fs/atomic.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/adapters/fs/filesystem.go
+++ b/file-engine/internal/adapters/fs/filesystem.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/adapters/fs/fs_utils.go
+++ b/file-engine/internal/adapters/fs/fs_utils.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/adapters/fs/local_fs.go
+++ b/file-engine/internal/adapters/fs/local_fs.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/adapters/fs/sftp_fs.go
+++ b/file-engine/internal/adapters/fs/sftp_fs.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/adapters/queue/redis_queue.go
+++ b/file-engine/internal/adapters/queue/redis_queue.go
@@ -1,0 +1,1 @@
+package queue

--- a/file-engine/internal/adapters/storage/local/local_storage_test.go
+++ b/file-engine/internal/adapters/storage/local/local_storage_test.go
@@ -1,4 +1,4 @@
-package localstorage
+package local
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/example/file-engine/internal/storage"
 )
 
 func TestLocalStorageListMetadata(t *testing.T) {
@@ -28,7 +30,7 @@ func TestLocalStorageListMetadata(t *testing.T) {
 		t.Fatalf("list: %v", err)
 	}
 
-	var file *ObjectInfo
+	var file *storage.ObjectInfo
 	for i := range items {
 		if items[i].Path == "/tenants/acme/projects/report.txt" {
 			file = &items[i]

--- a/file-engine/internal/app/ports/fs.port.go
+++ b/file-engine/internal/app/ports/fs.port.go
@@ -1,0 +1,1 @@
+package ports

--- a/file-engine/internal/app/ports/task_queue_port.go
+++ b/file-engine/internal/app/ports/task_queue_port.go
@@ -1,0 +1,1 @@
+package ports

--- a/file-engine/internal/app/services/file_service.go
+++ b/file-engine/internal/app/services/file_service.go
@@ -1,0 +1,1 @@
+package services

--- a/file-engine/internal/delivery/grpc/fileengine_server.go
+++ b/file-engine/internal/delivery/grpc/fileengine_server.go
@@ -1,0 +1,1 @@
+package grpc

--- a/file-engine/internal/delivery/http/gateway.go
+++ b/file-engine/internal/delivery/http/gateway.go
@@ -1,0 +1,1 @@
+package http

--- a/file-engine/internal/fs/fs_utils.go
+++ b/file-engine/internal/fs/fs_utils.go
@@ -1,0 +1,1 @@
+package fs

--- a/file-engine/internal/infra/logger/logger.go
+++ b/file-engine/internal/infra/logger/logger.go
@@ -1,0 +1,1 @@
+package logger

--- a/file-engine/internal/infra/security/sftp_keyloader.go
+++ b/file-engine/internal/infra/security/sftp_keyloader.go
@@ -1,0 +1,1 @@
+package security

--- a/file-engine/internal/security/validator.go
+++ b/file-engine/internal/security/validator.go
@@ -1,0 +1,1 @@
+package security

--- a/file-engine/pkg/util/atomic.go
+++ b/file-engine/pkg/util/atomic.go
@@ -1,0 +1,1 @@
+package util

--- a/file-engine/tests/fs/fs_local_test.go
+++ b/file-engine/tests/fs/fs_local_test.go
@@ -1,0 +1,1 @@
+package fs


### PR DESCRIPTION
### Motivation
- Snyk scan was failing with `SNYK-CLI-0000` because multiple zero-byte `.go` files parsed as EOF (`expected 'package', found 'EOF'`) and broke `go list` dependency analysis. 
- CI Go toolchain should be derived from the module to avoid `go build`/`go mod download` toolchain mismatches.

### Description
- Updated `.github/workflows/snyk-scan.yaml` to use `actions/setup-go@v6` with `go-version-file: 'file-engine/go.mod'` so the runner Go version matches the module requirement. 
- Added a single-line `package ...` declaration to all previously empty placeholder `.go` files under `file-engine/` so they are syntactically valid and no longer break `go list`. 
- Adjusted `internal/adapters/storage/local/local_storage_test.go` to use package `local` and changed the test `ObjectInfo` reference to `storage.ObjectInfo` to align test types with the implementation.

### Testing
- Ran `cd file-engine && go list -json -deps ./...` which completed successfully and produced `/tmp/golist.json`. 
- Ran `cd file-engine && go test ./internal/adapters/storage/local ./internal/handlers` and these package tests succeeded (cached). 
- Attempted `cd file-engine && snyk test --file=go.mod --severity-threshold=high`, but the `snyk` CLI is not installed in this environment so that check could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924128ee34832d92520dc26371f4b1)