### PR TITLE
feat: Add documented worker timeout and retry guardrails (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Every baseline claim is mapped to a claim ID and runnable command in the capabil
 | [`CL-004`](docs/capability-ledger.md#baseline-claims-implemented) | Task status persistence (`queued -> running -> success`) | ✅ | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` |
 | [`CL-005`](docs/capability-ledger.md#baseline-claims-implemented) | Basic audit event emission (`task.processing`, `task.succeeded`) | ✅ | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` |
 | [`CL-006`](docs/capability-ledger.md#baseline-claims-implemented) | Correlation ID propagation in async flow | ✅ | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` |
+| [`CL-017`](docs/capability-ledger.md#baseline-claims-implemented) | Worker performance guardrails (status retries + task timeout) for async create-folder | ✅ | `cd file-engine && go test ./internal/app/tasks -run "TestWorkerRetriesStatusPersistence|TestWorkerMarksTaskFailedOnProcessingTimeout" -v` |
 | [`CL-007`](docs/capability-ledger.md#baseline-claims-implemented) | Known-working local dev script | ✅ | `./file-engine/scripts/dev.sh` |
 | [`CL-008`](docs/capability-ledger.md#baseline-claims-implemented) | Backend scaffold validation | 🟡 | `cd backend && composer validate --strict` |
 | [`CL-009`](docs/capability-ledger.md#baseline-claims-implemented) | Frontend placeholder scaffold | 🔒 | `test -f frontend/README.md && test ! -f frontend/package.json` |
@@ -444,6 +445,11 @@ export STORAGE_BACKEND="local"
 export FILE_BASE_ROOT="$PWD/data"
 export JWT_SECRET="dev-secret"
 export TENANT_MEMBERSHIPS="dev-admin=dev-tenant"
+
+# Optional worker guardrails (defaults shown in parentheses):
+# export WORKER_STATUS_RETRY_ATTEMPTS="3"
+# export WORKER_STATUS_RETRY_DELAY_MS="25"
+# export WORKER_TASK_PROCESS_TIMEOUT_MS="30000"
 
 go run ./cmd/migrate
 ```

--- a/docs/capability-ledger.md
+++ b/docs/capability-ledger.md
@@ -28,6 +28,7 @@ This ledger is the canonical claim-to-validation source for the repository.
 | `CL-014` | AuthZ precedence (ACL vs RBAC) behaves as specified | ✅ | `cd file-engine && go test ./internal/auth -run "TestRBACFallback|TestUserACLOverridesRBAC|TestACLPathInheritance|TestUserDenyPrecedesRoleAllowAndRBAC|TestRoleDenyPrecedesRoleAllowAtSamePath|TestClosestPathACLWinsBeforeParentACLs|TestUserACLPrecedenceOnSamePath|TestUserACLWithoutPermissionFallsThroughToRoleACL" -v` | Tests pass |
 | `CL-015` | Path normalization guarantees (traversal rejection + canonicalization) | ✅ | `cd file-engine && go test ./internal/authz -run "TestExtractPathNormalizesCreateFolder|TestExtractPathRejectsTraversal|TestNormalizePathHandlesWindowsAndWhitespace|TestNormalizePathAllowsDotContainingNames|TestTenantFromPath|TestTenantFromPathRejectsNonTenantRoot" -v` | Tests pass |
 | `CL-016` | Generated gateway artifacts are in sync with proto | ✅ | `cd file-engine && ./scripts/generate_grpc_docker.sh && cd .. && git diff --exit-code && test -z "$(git status --porcelain)"` | No diff after generation |
+| `CL-017` | Worker performance guardrails for async create-folder are enforced (bounded status retries + processing timeout) | ✅ | `cd file-engine && go test ./internal/app/tasks -run "TestWorkerRetriesStatusPersistence|TestWorkerMarksTaskFailedOnProcessingTimeout" -v` | Tests pass |
 
 ## Domain capability ledger (by area)
 
@@ -36,7 +37,7 @@ This section summarizes capability status by domain with ownership, acceptance t
 | Domain | Current state | Owner | Acceptance tests | Target milestone |
 | :-- | :-- | :-- | :-- | :-- |
 | AuthZ | Baseline RBAC + path-based ACL with inheritance is implemented; tenant scoping enforced at File Engine boundary. | Unassigned (TBD) | `cd file-engine && go test ./internal/auth -v` | Phase 1 (read authz baseline) |
-| Tasks | Async task enqueue + worker execution + status persistence validated for create-folder flow. | Unassigned (TBD) | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` | Phase 2 (folder creation + audit) |
+| Tasks | Async task enqueue + worker execution + status persistence validated for create-folder flow, with worker guardrails for bounded retries and processing timeout. | Unassigned (TBD) | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` and `cd file-engine && go test ./internal/app/tasks -run "TestWorkerRetriesStatusPersistence|TestWorkerMarksTaskFailedOnProcessingTimeout" -v` | Phase 2 (folder creation + audit) |
 | Uploads | Quarantine → scan → promote is target-state only; no baseline validation yet. | Unassigned (TBD) | TBD (promote to ledger when runnable) | Phase 3 (upload + scan + observability) |
 | Audit | Baseline task audit events are emitted for async folder flow; external sink is target-state. | Unassigned (TBD) | `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` | Phase 2 baseline; Phase 3 for sink |
 | Observability | Structured logs + queue/task metrics baseline in place; OTEL export is target-state. | Unassigned (TBD) | `cd file-engine && go test ./internal/handlers ./internal/observability -v` | Phase 3 (observability baseline) |

--- a/docs/project-alignment-review.md
+++ b/docs/project-alignment-review.md
@@ -56,6 +56,7 @@ The project clearly distinguishes baseline vs target-state claims and anchors va
 - The control-plane (Laravel) vs data-plane (Go File Engine) split remains coherent.
 - Asynchronous mutation design is a solid fit for filesystem operations and security gates.
 - The baseline async create-folder flow provides a credible, testable vertical slice.
+- Worker-side performance guardrails for async flow (bounded status retries + per-task processing timeout) are now implemented and covered by focused unit tests.
 
 **Risks**
 

--- a/file-engine/internal/app/tasks/worker.go
+++ b/file-engine/internal/app/tasks/worker.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,6 +11,12 @@ import (
 	"github.com/example/file-engine/internal/adapters/queue/redisq"
 	"github.com/example/file-engine/internal/logger"
 	"github.com/example/file-engine/internal/observability"
+)
+
+const (
+	defaultStatusRetryAttempts = 3
+	defaultStatusRetryDelay    = 25 * time.Millisecond
+	defaultTaskProcessTimeout  = 30 * time.Second
 )
 
 type Queue interface {
@@ -40,17 +47,38 @@ type Worker struct {
 	log                   *logger.Logger
 	auditor               AuditEmitter
 	failureAlertThreshold int64
+	statusRetryAttempts   int
+	statusRetryDelay      time.Duration
+	taskProcessTimeout    time.Duration
 }
 
 func NewWorker(q Queue, p *Processor, log *logger.Logger) *Worker {
-	return &Worker{q: q, p: p, log: log, auditor: &logAuditEmitter{log: log}, failureAlertThreshold: failureThresholdFromEnv()}
+	return &Worker{
+		q:                     q,
+		p:                     p,
+		log:                   log,
+		auditor:               &logAuditEmitter{log: log},
+		failureAlertThreshold: failureThresholdFromEnv(),
+		statusRetryAttempts:   statusRetryAttemptsFromEnv(),
+		statusRetryDelay:      statusRetryDelayFromEnv(),
+		taskProcessTimeout:    taskProcessTimeoutFromEnv(),
+	}
 }
 
 func NewWorkerWithAudit(q Queue, p *Processor, log *logger.Logger, auditor AuditEmitter) *Worker {
 	if auditor == nil {
 		auditor = &logAuditEmitter{log: log}
 	}
-	return &Worker{q: q, p: p, log: log, auditor: auditor, failureAlertThreshold: failureThresholdFromEnv()}
+	return &Worker{
+		q:                     q,
+		p:                     p,
+		log:                   log,
+		auditor:               auditor,
+		failureAlertThreshold: failureThresholdFromEnv(),
+		statusRetryAttempts:   statusRetryAttemptsFromEnv(),
+		statusRetryDelay:      statusRetryDelayFromEnv(),
+		taskProcessTimeout:    taskProcessTimeoutFromEnv(),
+	}
 }
 
 func (w *Worker) Start(ctx context.Context) {
@@ -63,7 +91,14 @@ func (w *Worker) Start(ctx context.Context) {
 		}
 		task, err := w.q.Pop(ctx)
 		if err != nil {
-			time.Sleep(1 * time.Second)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				w.log.Info("worker context done")
+				return
+			}
+			if !w.sleepWithContext(ctx, 1*time.Second) {
+				w.log.Info("worker context done")
+				return
+			}
 			continue
 		}
 		correlationID := task.Params["correlation_id"]
@@ -74,25 +109,71 @@ func (w *Worker) Start(ctx context.Context) {
 			"correlation_id": correlationID,
 			"task_type":      task.Type,
 		})
-		if err := w.q.Complete(ctx, task.ID, "running", correlationID, "task is running"); err != nil {
+		if err := w.persistStatus(ctx, task.ID, "running", correlationID, "task is running"); err != nil {
 			w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": err.Error()})
 		}
 
-		if err := w.p.Process(ctx, task); err != nil {
+		processCtx := ctx
+		cancel := func() {}
+		if w.taskProcessTimeout > 0 {
+			processCtx, cancel = context.WithTimeout(ctx, w.taskProcessTimeout)
+		}
+		err = w.p.Process(processCtx, task)
+		cancel()
+
+		if err != nil {
 			msg := err.Error()
+			if errors.Is(err, context.DeadlineExceeded) {
+				msg = fmt.Sprintf("task processing timed out after %s", w.taskProcessTimeout)
+			}
 			w.log.Event("warn", "worker task failed", map[string]any{"event": "task.failed", "task_id": task.ID, "correlation_id": correlationID, "error": msg})
-			if completeErr := w.q.Complete(ctx, task.ID, "failed", correlationID, msg); completeErr != nil {
+			if completeErr := w.persistStatus(ctx, task.ID, "failed", correlationID, msg); completeErr != nil {
 				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": completeErr.Error()})
 			}
 			w.auditor.EmitTaskEvent(ctx, "task.failed", task.ID, correlationID, msg)
 			w.maybeAlertOnFailures(correlationID)
 		} else {
 			w.log.Event("info", "worker task succeeded", map[string]any{"event": "task.succeeded", "task_id": task.ID, "correlation_id": correlationID})
-			if completeErr := w.q.Complete(ctx, task.ID, "success", correlationID, "folder created"); completeErr != nil {
+			if completeErr := w.persistStatus(ctx, task.ID, "success", correlationID, "folder created"); completeErr != nil {
 				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": completeErr.Error()})
 			}
 			w.auditor.EmitTaskEvent(ctx, "task.succeeded", task.ID, correlationID, "task completed")
 		}
+	}
+}
+
+func (w *Worker) persistStatus(ctx context.Context, id, status, correlationID, message string) error {
+	attempts := w.statusRetryAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = w.q.Complete(ctx, id, status, correlationID, message)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		if attempt < attempts && !w.sleepWithContext(ctx, w.statusRetryDelay) {
+			return context.Canceled
+		}
+	}
+	return err
+}
+
+func (w *Worker) sleepWithContext(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return true
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 
@@ -119,4 +200,37 @@ func failureThresholdFromEnv() int64 {
 		}
 	}
 	return threshold
+}
+
+func statusRetryAttemptsFromEnv() int {
+	attempts := defaultStatusRetryAttempts
+	if raw := os.Getenv("WORKER_STATUS_RETRY_ATTEMPTS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			attempts = parsed
+		}
+	}
+	return attempts
+}
+
+func statusRetryDelayFromEnv() time.Duration {
+	delay := defaultStatusRetryDelay
+	if raw := os.Getenv("WORKER_STATUS_RETRY_DELAY_MS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
+			delay = time.Duration(parsed) * time.Millisecond
+		}
+	}
+	return delay
+}
+
+func taskProcessTimeoutFromEnv() time.Duration {
+	timeout := defaultTaskProcessTimeout
+	if raw := os.Getenv("WORKER_TASK_PROCESS_TIMEOUT_MS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil {
+			if parsed <= 0 {
+				return 0
+			}
+			timeout = time.Duration(parsed) * time.Millisecond
+		}
+	}
+	return timeout
 }

--- a/file-engine/internal/app/tasks/worker_test.go
+++ b/file-engine/internal/app/tasks/worker_test.go
@@ -1,0 +1,169 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/example/file-engine/internal/adapters/queue/redisq"
+	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/storage"
+)
+
+type workerTestQueue struct {
+	task             *redisq.TaskPayload
+	completeCalls    map[string]int
+	failuresByStatus map[string]int
+	statuses         []redisq.TaskStatus
+	terminalStatusCh chan redisq.TaskStatus
+	mu               sync.Mutex
+}
+
+func newWorkerTestQueue(task *redisq.TaskPayload) *workerTestQueue {
+	return &workerTestQueue{
+		task:             task,
+		completeCalls:    map[string]int{},
+		failuresByStatus: map[string]int{},
+		terminalStatusCh: make(chan redisq.TaskStatus, 1),
+	}
+}
+
+func (q *workerTestQueue) Pop(ctx context.Context) (*redisq.TaskPayload, error) {
+	if q.task != nil {
+		t := q.task
+		q.task = nil
+		return t, nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (q *workerTestQueue) Complete(_ context.Context, id, status, correlationID, message string) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.completeCalls[status]++
+	if pending := q.failuresByStatus[status]; pending > 0 {
+		q.failuresByStatus[status] = pending - 1
+		return errors.New("transient queue write error")
+	}
+	current := redisq.TaskStatus{TaskID: id, Status: status, CorrelationID: correlationID, Message: message}
+	q.statuses = append(q.statuses, current)
+	if status == "success" || status == "failed" {
+		select {
+		case q.terminalStatusCh <- current:
+		default:
+		}
+	}
+	return nil
+}
+
+func (q *workerTestQueue) setStatusFailures(status string, failures int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.failuresByStatus[status] = failures
+}
+
+func (q *workerTestQueue) completeCallsFor(status string) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.completeCalls[status]
+}
+
+type workerTestStorage struct {
+	processDelay time.Duration
+}
+
+func (s *workerTestStorage) CreateFolder(ctx context.Context, path string) error {
+	if s.processDelay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(s.processDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *workerTestStorage) AtomicWrite(context.Context, string, io.Reader) error { return nil }
+func (s *workerTestStorage) Move(context.Context, string, string) error           { return nil }
+func (s *workerTestStorage) Delete(context.Context, string) error                 { return nil }
+func (s *workerTestStorage) Exists(context.Context, string) (bool, error)         { return false, nil }
+func (s *workerTestStorage) List(context.Context, string) ([]storage.ObjectInfo, error) {
+	return nil, nil
+}
+func (s *workerTestStorage) Open(context.Context, string) (io.ReadCloser, error) { return nil, nil }
+
+func TestWorkerRetriesStatusPersistence(t *testing.T) {
+	t.Setenv("WORKER_STATUS_RETRY_ATTEMPTS", "3")
+	t.Setenv("WORKER_STATUS_RETRY_DELAY_MS", "1")
+	t.Setenv("WORKER_TASK_PROCESS_TIMEOUT_MS", "1000")
+
+	q := newWorkerTestQueue(&redisq.TaskPayload{
+		ID:   "task-retry",
+		Type: "create_folder",
+		Params: map[string]string{
+			"parent":         "tenants/acme/projects",
+			"name":           "guardrail",
+			"correlation_id": "req-retry-1",
+		},
+	})
+	q.setStatusFailures("running", 2)
+
+	worker := NewWorkerWithAudit(q, NewProcessorWithStorage(&workerTestStorage{}), logger.New("debug"), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go worker.Start(ctx)
+
+	select {
+	case terminal := <-q.terminalStatusCh:
+		if terminal.Status != "success" {
+			t.Fatalf("expected success terminal status, got %+v", terminal)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for worker terminal status")
+	}
+
+	if attempts := q.completeCallsFor("running"); attempts != 3 {
+		t.Fatalf("expected 3 attempts for running status persistence, got %d", attempts)
+	}
+}
+
+func TestWorkerMarksTaskFailedOnProcessingTimeout(t *testing.T) {
+	t.Setenv("WORKER_TASK_PROCESS_TIMEOUT_MS", "20")
+	t.Setenv("WORKER_STATUS_RETRY_ATTEMPTS", "1")
+	t.Setenv("WORKER_STATUS_RETRY_DELAY_MS", "0")
+
+	q := newWorkerTestQueue(&redisq.TaskPayload{
+		ID:   "task-timeout",
+		Type: "create_folder",
+		Params: map[string]string{
+			"parent":         "tenants/acme/projects",
+			"name":           "slow-folder",
+			"correlation_id": "req-timeout-1",
+		},
+	})
+
+	worker := NewWorkerWithAudit(q, NewProcessorWithStorage(&workerTestStorage{processDelay: 250 * time.Millisecond}), logger.New("debug"), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go worker.Start(ctx)
+
+	select {
+	case terminal := <-q.terminalStatusCh:
+		if terminal.Status != "failed" {
+			t.Fatalf("expected failed terminal status due to timeout, got %+v", terminal)
+		}
+		if !strings.Contains(terminal.Message, "timed out") {
+			t.Fatalf("expected timeout message, got %q", terminal.Message)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for worker terminal status")
+	}
+}

--- a/file-engine/tests/integration/worker_integration_test.go
+++ b/file-engine/tests/integration/worker_integration_test.go
@@ -85,24 +85,27 @@ func (q *inMemoryQueue) TransitionHistory(id string) []string {
 
 type inMemoryAuditor struct {
 	mu     sync.Mutex
-	events []string
+	events []auditEvent
+}
+
+type auditEvent struct {
+	event         string
+	taskID        string
+	correlationID string
 }
 
 func (a *inMemoryAuditor) EmitTaskEvent(_ context.Context, event, taskID, correlationID, _ string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.events = append(a.events, fmt.Sprintf("%s|%s|%s", event, taskID, correlationID))
+	a.events = append(a.events, auditEvent{event: event, taskID: taskID, correlationID: correlationID})
 }
 
-func (a *inMemoryAuditor) Contains(prefix string) bool {
+func (a *inMemoryAuditor) Snapshot() []auditEvent {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	for _, e := range a.events {
-		if len(e) >= len(prefix) && e[:len(prefix)] == prefix {
-			return true
-		}
-	}
-	return false
+	out := make([]auditEvent, len(a.events))
+	copy(out, a.events)
+	return out
 }
 
 // TestAsyncCreateFolderFlow validates one end-to-end async folder flow:
@@ -151,13 +154,6 @@ func TestAsyncCreateFolderFlow(t *testing.T) {
 			if !info.IsDir() {
 				t.Fatalf("expected %s to be a directory", expectedPath)
 			}
-			if !auditor.Contains("task.processing|" + taskID + "|" + correlationID) {
-				t.Fatalf("expected audit processing event for task %s", taskID)
-			}
-			if !auditor.Contains("task.succeeded|" + taskID + "|" + correlationID) {
-				t.Fatalf("expected audit success event for task %s", taskID)
-			}
-
 			history := queue.TransitionHistory(taskID)
 			expected := []string{"queued", "running", "success"}
 			if len(history) != len(expected) {
@@ -167,6 +163,17 @@ func TestAsyncCreateFolderFlow(t *testing.T) {
 				if history[i] != expected[i] {
 					t.Fatalf("expected transition history %v, got %v", expected, history)
 				}
+			}
+
+			auditEvents := auditor.Snapshot()
+			if len(auditEvents) != 2 {
+				t.Fatalf("expected exactly 2 audit events, got %d (%+v)", len(auditEvents), auditEvents)
+			}
+			if auditEvents[0] != (auditEvent{event: "task.processing", taskID: taskID, correlationID: correlationID}) {
+				t.Fatalf("expected first audit event to be task.processing for task %s, got %+v", taskID, auditEvents[0])
+			}
+			if auditEvents[1] != (auditEvent{event: "task.succeeded", taskID: taskID, correlationID: correlationID}) {
+				t.Fatalf("expected second audit event to be task.succeeded for task %s, got %+v", taskID, auditEvents[1])
 			}
 			return
 		}


### PR DESCRIPTION
### Motivation
- Reduce transient failures when persisting task status by adding bounded retry behavior for status writes.
- Prevent runaway/slow tasks from blocking the worker by enforcing a per-task processing timeout guardrail.
- Make the async create-folder reference slice deterministic and observable by wiring audit emission and documenting the guardrails.

### Description
- Add configurable worker guardrails in `internal/app/tasks/worker.go`: `WORKER_STATUS_RETRY_ATTEMPTS`, `WORKER_STATUS_RETRY_DELAY_MS`, and `WORKER_TASK_PROCESS_TIMEOUT_MS` with sensible defaults and env parsing helpers.
- Implement `persistStatus` helper with bounded retries and context-aware backoff, plus `sleepWithContext` to ensure prompt shutdown on canceled/deadline contexts.
- Wrap task processing in a per-task `context.WithTimeout` so long-running storage operations produce a terminal `failed` status with a timeout message. 
- Add unit tests in `internal/app/tasks/worker_test.go` to validate retry behavior (`TestWorkerRetriesStatusPersistence`) and timeout/failure semantics (`TestWorkerMarksTaskFailedOnProcessingTimeout`), and update integration auditor assertions to a structured `auditEvent` snapshot in `tests/integration/worker_integration_test.go`.

### Testing
- Ran `cd file-engine && go test ./internal/config ./internal/logger ./internal/worker -v` and it passed. 
- Ran `cd file-engine && go test ./internal/app/tasks -run "TestWorkerRetriesStatusPersistence|TestWorkerMarksTaskFailedOnProcessingTimeout" -v` and both unit tests passed. 
- Ran `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` and the integration test passed.
