### PR TITLE
docs: align governance merge gates with current CI and branch protection

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,6 +1,6 @@
 # Governance — Merge Gates & Workflow Policy
 
-This document defines the **required checks for merge** and how advanced security workflows are handled. The goal is a compact, reliable core gate that scales with the project, while keeping advanced security checks running without blocking progress until they are stable.
+This document defines the **required checks for merge** and how advanced security workflows are handled. The goal is a compact, reliable core gate that scales with the project, while keeping advanced security checks running in CI with clear promotion criteria into branch-protection requirements.
 
 ---
 
@@ -13,13 +13,15 @@ These checks are required for **all** merges to `main`:
      - Backend scaffold validation
      - Frontend scaffold validation
      - File Engine baseline checks (`./file-engine/scripts/dev.sh`)
+     - File Engine gateway route race test (`go test -race ./internal/server -run TestGatewayCreateFolderAndGetTaskStatusRoutes -v`)
+     - File Engine generated gateway artifact drift check
      - Doc drift check
 2. **Lint (required category)**
-   - **Status:** Not yet implemented in CI.
-   - **Policy:** Once a lint job exists, it becomes required. Until then, maintainers should run lint locally for touched components (Go, PHP, JS) and note the command in the PR.
+   - **Status:** Implemented in CI for Go (`lint-go` job in `.github/workflows/ci.yml`, scoped to `file-engine/**` changes).
+   - **Policy:** `lint-go` is required for merge when triggered by file-engine changes.
 3. **Dependency scan (required category)**
-   - **Status:** Snyk scan workflow exists; dependency review is optional.
-   - **Policy:** Snyk scan should be required once the workflow is stable and consistently green. Until then, it runs as non-blocking but must be reviewed for new high/critical findings in each PR.
+   - **Status:** Snyk PR scan is active in `.github/workflows/snyk-scan.yaml`.
+   - **Policy:** Snyk is branch-protection gated for PR merges; merge is blocked until the scan is green.
 
 ---
 
@@ -28,7 +30,7 @@ These checks are required for **all** merges to `main`:
 These workflows continue to run but do not gate merges until they are stable and have low false positives:
 
 - CodeQL
-- Snyk snapshot / monitoring
+- Snyk snapshot / monitoring (for post-merge visibility beyond PR gate)
 - Dependabot auto-merge workflows (scoped to patch/minor)
 
 When any of these are promoted to required, update this doc and the branch protection rules together.
@@ -40,7 +42,4 @@ When any of these are promoted to required, update this doc and the branch prote
 Before merging:
 
 1. All core merge gates are green.
-2. If lint or dependency scan is not yet required in CI, the PR includes:
-   - the commands run, and
-   - a brief summary of results.
-3. Docs are updated if behavior, contracts, or setup guidance changed.
+2. Docs are updated if behavior, contracts, or setup guidance changed.


### PR DESCRIPTION
### Motivation

- Update governance guidance to reflect current CI behavior: the repository now runs a Go lint job for `file-engine`, executes a gateway route race test and generated-artifact drift check in CI, and enforces Snyk PR scans via branch protection.

### Description

- Update `docs/governance.md` to add the File Engine gateway race test and generated gateway artifact drift check to the core build/tests gate. 
- Update `docs/governance.md` to mark the Go lint job (`lint-go`) as implemented in CI and required when `file-engine/**` changes trigger it. 
- Update `docs/governance.md` to document that Snyk PR scans are active (`.github/workflows/snyk-scan.yaml`) and that branch protection blocks merges until the scan is green. 
- Simplify the enforcement checklist and clarify that Snyk snapshot/monitoring remains a post-merge visibility workflow.

### Testing

- This is a documentation-only change; verification steps executed successfully were `git status --short`, `git show --stat --oneline HEAD`, printing the patched `docs/governance.md`, and inspecting `.github/workflows/ci.yml` and `.github/workflows/snyk-scan.yaml`, and all checks/inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993bb7bc84c832d950dfeba6366117a)