### PR TITLE
feat: Add readiness probes, RED/security metrics, and request-id traceability

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -49,7 +49,7 @@ Run from repository root unless noted:
 - Some docs still describe target-state capabilities as implemented; verify with capability ledger commands before claiming support.
 - HTTP/JSON via gRPC-Gateway is baseline for `CreateFolder` + `GetTaskStatus`; upload routes remain target-state.
 - `docker/docker-compose.yml` is a legacy/alternate compose path and should not override canonical setup guidance.
-- Root `docker-compose.yml` is experimental and not a baseline-validated runtime path.
+- Root `docker-compose.yml` is the canonical developer compose entry point.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -476,9 +476,11 @@ Dev JWT (HS256 with `JWT_SECRET=dev-secret`, `sub=dev-admin`, `roles=["admin"]`)
 export JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkZXYtYWRtaW4iLCJyb2xlcyI6WyJhZG1pbiJdLCJleHAiOjQxMDI0NDQ4MDB9.Y-JdrUO96XS3odOeBWtYSIjPwR7z7g7IytvBLxTbCus"
 ```
 
-### 4) Root `docker-compose.yml` (experimental)
+### 4) Canonical compose entry point
 
-The root compose file is **experimental** until it is validated end-to-end. Use it only for container build validation, not as a baseline-validated runtime.
+Use **repository-root `docker-compose.yml`** as the primary developer compose entry point.
+
+`file-engine/docker-compose.yml` remains only as a compatibility mirror and should not be treated as the canonical source.
 
 **Default ports:**
 
@@ -488,7 +490,7 @@ The root compose file is **experimental** until it is validated end-to-end. Use 
 - Postgres: `5432`
 
 > [!Note]
-> All setup flows (local File Engine run, experimental root compose, dev JWT) are documented in `docs/setup.md`.
+> All setup flows (local File Engine run, canonical root compose, dev JWT) are documented in `docs/setup.md`.
 
 ---
 

--- a/backend/app/Http/Controllers/FolderController.php
+++ b/backend/app/Http/Controllers/FolderController.php
@@ -22,6 +22,10 @@ class FolderController extends Controller
 
         $requestedBy = (string) ($request->input('requestedBy') ?? optional($request->user())->email ?? 'system');
 
-        return new JsonResponse($this->engine->createFolder($path, $folderName, $requestedBy));
+        $payload = $this->engine->createFolder($path, $folderName, $requestedBy);
+        $status = (int) ($payload['_engine_http_status'] ?? 200);
+        unset($payload['_engine_http_status']);
+
+        return new JsonResponse($payload, $status);
     }
 }

--- a/backend/app/Http/Controllers/TaskController.php
+++ b/backend/app/Http/Controllers/TaskController.php
@@ -13,6 +13,10 @@ class TaskController extends Controller
 
     public function show(string $id): JsonResponse
     {
-        return new JsonResponse($this->engine->getTask($id));
+        $payload = $this->engine->getTask($id);
+        $status = (int) ($payload['_engine_http_status'] ?? 200);
+        unset($payload['_engine_http_status']);
+
+        return new JsonResponse($payload, $status);
     }
 }

--- a/backend/app/Http/Controllers/UploadController.php
+++ b/backend/app/Http/Controllers/UploadController.php
@@ -24,11 +24,15 @@ class UploadController extends Controller
 
         $requestedBy = (string) ($request->input('requestedBy') ?? optional($request->user())->email ?? 'system');
 
-        return new JsonResponse($this->engine->initiateUpload([
+        $payload = $this->engine->initiateUpload([
             'path' => $path,
             'filename' => $filename,
             'mimeType' => $mimeType,
-        ], $requestedBy));
+        ], $requestedBy);
+        $status = (int) ($payload['_engine_http_status'] ?? 200);
+        unset($payload['_engine_http_status']);
+
+        return new JsonResponse($payload, $status);
     }
 
     public function complete(Request $request): JsonResponse
@@ -38,6 +42,10 @@ class UploadController extends Controller
             return new JsonResponse(['message' => 'uploadId is required'], 422);
         }
 
-        return new JsonResponse($this->engine->completeUpload($uploadId));
+        $payload = $this->engine->completeUpload($uploadId);
+        $status = (int) ($payload['_engine_http_status'] ?? 200);
+        unset($payload['_engine_http_status']);
+
+        return new JsonResponse($payload, $status);
     }
 }

--- a/backend/app/Services/FileEngineService.php
+++ b/backend/app/Services/FileEngineService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\Client\Response;
 
 class FileEngineService
 {
@@ -19,28 +20,42 @@ class FileEngineService
 
     public function createFolder(string $path, string $folderName, string $requestedBy): array
     {
-        return $this->http->post($this->base() . '/folders', [
+        $response = $this->http->post($this->base() . '/folders', [
             'path' => $path,
             'folderName' => $folderName,
             'createdBy' => $requestedBy,
-        ])->json();
+        ]);
+
+        return $this->withStatus($response);
     }
 
     public function initiateUpload(array $payload, string $requestedBy): array
     {
         $payload['createdBy'] = $requestedBy;
-        return $this->http->post($this->base() . '/uploads/initiate', $payload)->json();
+        return $this->withStatus($this->http->post($this->base() . '/uploads/initiate', $payload));
     }
 
     public function completeUpload(string $uploadId): array
     {
-        return $this->http->post($this->base() . '/uploads/complete', [
+        return $this->withStatus($this->http->post($this->base() . '/uploads/complete', [
             'uploadId' => $uploadId,
-        ])->json();
+        ]));
     }
 
     public function getTask(string $id): array
     {
-        return $this->http->get($this->base() . '/tasks/' . $id)->json();
+        return $this->withStatus($this->http->get($this->base() . '/tasks/' . $id));
+    }
+
+    private function withStatus(Response $response): array
+    {
+        $payload = $response->json();
+        if (!is_array($payload)) {
+            $payload = [];
+        }
+
+        $payload['_engine_http_status'] = $response->status();
+
+        return $payload;
     }
 }

--- a/backend/tests/Unit/ControllersTest.php
+++ b/backend/tests/Unit/ControllersTest.php
@@ -40,6 +40,21 @@ final class ControllersTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    public function testCreateFolderPropagatesEnginePermissionDeniedAuthoritatively(): void
+    {
+        $controller = new FolderController(new DeniedFileEngineService());
+        $request = Request::create('/folders', 'POST', [
+            'path' => 'tenants/beta',
+            'folderName' => 'secret',
+            'requestedBy' => 'owner@example.com',
+        ]);
+
+        $response = $controller->create($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame('tenant access denied', $response->getData(true)['message']);
+    }
+
     public function testInitiateAndCompleteUploadEndpoints(): void
     {
         $controller = new UploadController(new FakeFileEngineService());
@@ -95,6 +110,7 @@ final class FakeFileEngineService extends FileEngineService
     public function createFolder(string $path, string $folderName, string $requestedBy): array
     {
         return [
+            '_engine_http_status' => 200,
             'taskId' => 'task-123',
             'status' => 'queued',
             'path' => $path,
@@ -106,6 +122,7 @@ final class FakeFileEngineService extends FileEngineService
     public function initiateUpload(array $payload, string $requestedBy): array
     {
         return [
+            '_engine_http_status' => 200,
             'uploadId' => 'upl-1',
             'uploadUrl' => 'http://upload.local/upl-1',
             'requestedBy' => $requestedBy,
@@ -116,6 +133,7 @@ final class FakeFileEngineService extends FileEngineService
     public function completeUpload(string $uploadId): array
     {
         return [
+            '_engine_http_status' => 200,
             'taskId' => 'task-complete',
             'status' => 'queued',
             'uploadId' => $uploadId,
@@ -125,9 +143,29 @@ final class FakeFileEngineService extends FileEngineService
     public function getTask(string $id): array
     {
         return [
+            '_engine_http_status' => 200,
             'taskId' => $id,
             'status' => 'success',
             'message' => 'done',
+        ];
+    }
+}
+
+final class DeniedFileEngineService extends FileEngineService
+{
+    public function __construct()
+    {
+        parent::__construct(new HttpFactory(), 'http://example.test/v1');
+    }
+
+    public function createFolder(string $path, string $folderName, string $requestedBy): array
+    {
+        return [
+            '_engine_http_status' => 403,
+            'message' => 'tenant access denied',
+            'path' => $path,
+            'folderName' => $folderName,
+            'requestedBy' => $requestedBy,
         ];
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3.9"
 
 services:
-  # ------------ REDIS ---------------
   redis:
     image: redis:7.2
     container_name: redis
@@ -10,38 +9,60 @@ services:
     volumes:
       - redis_data:/data
 
-  # ------------ FILE ENGINE API (Go) ---------------
+  postgres:
+    image: postgres:16
+    container_name: postgres
+    environment:
+      POSTGRES_DB: fileengine
+      POSTGRES_USER: fileengine
+      POSTGRES_PASSWORD: fileengine
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
   file-engine:
     build:
       context: ./file-engine
       dockerfile: build/docker/server.Dockerfile
     container_name: file-engine
-    environment:
-      - PORT=8080
     ports:
       - "8080:8080"
+      - "50051:50051"
+    environment:
+      REDIS_ADDR: redis:6379
+      POSTGRES_DSN: postgres://fileengine:fileengine@postgres:5432/fileengine?sslmode=disable
+      FILE_BASE_ROOT: /mnt/files
+      STORAGE_BACKEND: local
     volumes:
-      - file_data:/mnt/files  # Aqui ficam as pastas reais
+      - file_data:/mnt/files
     depends_on:
       - redis
+      - postgres
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:8080/readyz >/dev/null"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
-  # ------------ FILE ENGINE WORKER (Go) ---------------
   file-engine-worker:
     build:
       context: ./file-engine
       dockerfile: build/docker/worker.Dockerfile
     container_name: file-engine-worker
     environment:
-      - REDIS_ADDR=redis:6379
-      - FILE_BASE_ROOT=/mnt/files
-      - STORAGE_BACKEND=local
+      REDIS_ADDR: redis:6379
+      POSTGRES_DSN: postgres://fileengine:fileengine@postgres:5432/fileengine?sslmode=disable
+      FILE_BASE_ROOT: /mnt/files
+      STORAGE_BACKEND: local
     depends_on:
       - redis
+      - postgres
       - file-engine
     volumes:
       - file_data:/mnt/files
 
-  # ------------ BACKEND LARAVEL API ---------------
   backend:
     build:
       context: ./backend
@@ -49,14 +70,13 @@ services:
     ports:
       - "9000:9000"
     environment:
-      - FILE_ENGINE_URL=http://file-engine:8080/v1
-      - DB_CONNECTION=sqlite
+      FILE_ENGINE_URL: http://file-engine:8080/v1
+      DB_CONNECTION: sqlite
     volumes:
       - ./backend:/var/www
     depends_on:
       - file-engine
 
-  # ------------ NGINX (para servir Laravel) ---------------
   nginx:
     image: nginx:1.25
     container_name: nginx
@@ -64,10 +84,11 @@ services:
       - "80:80"
     volumes:
       - ./backend:/var/www
-      - ./docker/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - backend
 
 volumes:
   redis_data:
   file_data:
+  pgdata:

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ The `docs/` directory contains project-wide documentation for the File Server Ma
 
 ### Getting Started
 
-Baseline onboarding is `./file-engine/scripts/dev.sh`; the root `docker-compose.yml` is experimental until validated end-to-end.
+Baseline onboarding is `./file-engine/scripts/dev.sh`; root `docker-compose.yml` is the canonical compose entry point.
 
 - [Setup & Developer Onboarding](setup.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This document describes the platform-level architecture: components, trust boundaries, data flows, and operational characteristics.
 
-Baseline onboarding is `./file-engine/scripts/dev.sh`; the root `docker-compose.yml` is experimental until validated end-to-end. See `docs/setup.md` for the canonical paths.
+Baseline onboarding is `./file-engine/scripts/dev.sh`; repository-root `docker-compose.yml` is the canonical compose entry point. See `docs/setup.md` for canonical paths.
 
 ---
 

--- a/docs/architecture_file-engine.md
+++ b/docs/architecture_file-engine.md
@@ -6,7 +6,7 @@
 The File Engine is the data-plane service that performs filesystem mutations and enforces **final authorization** at the execution boundary.
 It operates directly on storage backends while enforcing **tenant membership**, **RBAC**, and **path-based ACLs**.
 
-Baseline onboarding is `./file-engine/scripts/dev.sh`; the root `docker-compose.yml` is experimental until validated end-to-end. See `docs/setup.md` for canonical paths.
+Baseline onboarding is `./file-engine/scripts/dev.sh`; root `docker-compose.yml` is the canonical compose entry point. See `docs/setup.md` for canonical paths.
 
 The system is built in Go and is **gRPC-first**. HTTP/JSON via gRPC-Gateway is **baseline** for `CreateFolder` and `GetTaskStatus`; upload and expanded read/write routes remain target-state.
 Filesystem mutations run **asynchronously** through a worker model.

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -32,7 +32,7 @@ Use the canonical onboarding guide in `docs/setup.md`. Baseline-validated path i
 ./file-engine/scripts/dev.sh
 ```
 
-If you need a full stack compose, note that the root `docker-compose.yml` is **experimental** until validated end-to-end.
+If you need a full stack compose, use root `docker-compose.yml` as the canonical developer entry point.
 Treat it as container-build validation only, not a baseline-validated runtime path.
 
 ---

--- a/docs/prod-checklist.md
+++ b/docs/prod-checklist.md
@@ -163,3 +163,22 @@ A minimal go-live gate you can treat as “definition of done”:
 - Add fine-grained permissions per operation (mkdir/move/write/delete/list)
 - Add antivirus scanning pipeline + quarantining
 - Add signed URLs / download tokens for controlled access
+
+---
+
+## 9) Automation hooks (implemented)
+
+Use these runtime checks as concrete deployment gates:
+
+- Readiness endpoint (`/readyz`) validates dependency connectivity:
+  - storage backend probe
+  - Redis queue probe (`PING`)
+  - Postgres probe (`Ping`) when `POSTGRES_DSN` is configured
+- Liveness endpoint (`/healthz`) remains process-level only.
+- Metrics endpoint (`/metrics`) exports RED counters/summaries for HTTP and gRPC, authz allow/deny reason counters, queue depth/lag, and upload duration.
+
+Suggested CI smoke checks:
+
+- `curl -fsS http://localhost:8080/healthz`
+- `curl -fsS http://localhost:8080/readyz`
+- `curl -fsS http://localhost:8080/metrics | rg "fileengine_(http_requests_total|grpc_requests_total|authz_decisions_total|queue_depth|queue_lag_ms|upload_duration_ms)"`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,7 +6,7 @@ This guide is the canonical setup reference for local development.
 
 - **Baseline validation (supported):** run `./file-engine/scripts/dev.sh` from repository root.
 - **File Engine local run (scaffold-level):** run Redis/Postgres in Docker, then run API/worker locally for debugging.
-- **Full stack compose (experimental):** `docker-compose.yml` builds containers, but backend/frontend are still scaffold-level and HTTP wiring is not yet a validated baseline.
+- **Primary compose entry point:** use repository-root `docker-compose.yml`.
 
 ---
 
@@ -84,6 +84,7 @@ This path is useful to validate container builds, but it is **not** a baseline-v
 
 ---
 
-## 4) Notes on legacy compose
+## 4) Notes on alternate compose files
 
-`docker/docker-compose.yml` is a legacy/alternate compose definition. It should not be treated as the primary onboarding path.
+- `file-engine/docker-compose.yml` is a compatibility mirror for file-engine-local workflows; the canonical source is root `docker-compose.yml`.
+- `docker/docker-compose.yml` is a legacy/alternate compose definition and should not be treated as primary onboarding.

--- a/file-engine/cmd/worker/main.go
+++ b/file-engine/cmd/worker/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/example/file-engine/internal/adapters/queue/redisq"
@@ -40,7 +41,19 @@ func main() {
 	}
 
 	proc := tasks.NewProcessorWithStorage(st)
-	worker := tasks.NewWorker(q, proc, logg)
+
+	var pgPool *pgxpool.Pool
+	if cfg.PostgresDSN != "" {
+		pool, err := pgxpool.New(context.Background(), cfg.PostgresDSN)
+		if err != nil {
+			logg.Fatalf("pg pool: %v", err)
+		}
+		pgPool = pool
+		defer pgPool.Close()
+	}
+
+	auditor := tasks.NewDualLayerAuditEmitter(logg, pgPool, os.Getenv("AUDIT_IMMUTABLE_SINK_PATH"))
+	worker := tasks.NewWorkerWithAudit(q, proc, logg, auditor)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/file-engine/db/migrations/0002_create_tenant_identity_tables.sql
+++ b/file-engine/db/migrations/0002_create_tenant_identity_tables.sql
@@ -1,0 +1,52 @@
+-- Tenant/user source-of-truth persistence for server-side membership resolution.
+
+CREATE TABLE IF NOT EXISTS tenants (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  email TEXT,
+  display_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_unique
+  ON users (email)
+  WHERE email IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS user_tenants (
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  tenant_id TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_tenants_tenant_id ON user_tenants(tenant_id);
+
+CREATE TABLE IF NOT EXISTS roles (
+  id TEXT PRIMARY KEY,
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS role_capabilities (
+  role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  capability TEXT NOT NULL,
+  allowed BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (role_id, capability)
+);
+
+CREATE TABLE IF NOT EXISTS user_tenant_roles (
+  user_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, tenant_id, role_id),
+  FOREIGN KEY (user_id, tenant_id) REFERENCES user_tenants(user_id, tenant_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_tenant_roles_role_id ON user_tenant_roles(role_id);

--- a/file-engine/db/migrations/0003_create_audit_events.sql
+++ b/file-engine/db/migrations/0003_create_audit_events.sql
@@ -1,0 +1,47 @@
+-- Queryable audit trail + append-only guardrails.
+
+CREATE TABLE IF NOT EXISTS audit_events (
+  id BIGSERIAL PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  task_id TEXT,
+  correlation_id TEXT,
+  message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_events_task_id ON audit_events(task_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_correlation_id ON audit_events(correlation_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_event_type ON audit_events(event_type);
+
+CREATE OR REPLACE FUNCTION audit_events_append_only_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_events is append-only; % is not allowed', TG_OP;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_audit_events_block_update ON audit_events;
+CREATE TRIGGER trg_audit_events_block_update
+BEFORE UPDATE ON audit_events
+FOR EACH ROW
+EXECUTE FUNCTION audit_events_append_only_guard();
+
+DROP TRIGGER IF EXISTS trg_audit_events_block_delete ON audit_events;
+CREATE TRIGGER trg_audit_events_block_delete
+BEFORE DELETE ON audit_events
+FOR EACH ROW
+EXECUTE FUNCTION audit_events_append_only_guard();
+
+REVOKE UPDATE, DELETE ON audit_events FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fileengine') THEN
+    REVOKE UPDATE, DELETE ON audit_events FROM fileengine;
+  END IF;
+END;
+$$;

--- a/file-engine/docker-compose.yml
+++ b/file-engine/docker-compose.yml
@@ -1,9 +1,16 @@
-version: '3.8'
+# Deprecated mirror for compatibility.
+# Canonical developer entry point is repository-root docker-compose.yml.
+# Keep this file in sync only as a compatibility fallback.
+
+version: "3.9"
+
 services:
   redis:
-    image: redis:7
+    image: redis:7.2
     ports:
-      - 6379:6379
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
 
   postgres:
     image: postgres:16
@@ -12,7 +19,7 @@ services:
       POSTGRES_USER: fileengine
       POSTGRES_PASSWORD: fileengine
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
 
@@ -21,8 +28,8 @@ services:
       context: .
       dockerfile: build/docker/server.Dockerfile
     ports:
-      - 8080:8080
-      - 50051:50051
+      - "8080:8080"
+      - "50051:50051"
     environment:
       REDIS_ADDR: redis:6379
       POSTGRES_DSN: postgres://fileengine:fileengine@postgres:5432/fileengine?sslmode=disable
@@ -51,4 +58,5 @@ services:
       - file-engine
 
 volumes:
+  redis_data:
   pgdata:

--- a/file-engine/internal/adapters/fs/atomic.go
+++ b/file-engine/internal/adapters/fs/atomic.go
@@ -1,0 +1,30 @@
+package fs
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func AtomicWriteFile(fullPath string, perm os.FileMode, r io.Reader) error {
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(fullPath), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := io.Copy(tmp, r); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), fullPath)
+}

--- a/file-engine/internal/adapters/fs/fs_utils.go
+++ b/file-engine/internal/adapters/fs/fs_utils.go
@@ -1,0 +1,24 @@
+package fs
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func SafeJoin(base string, parts ...string) (string, error) {
+	joined := filepath.Join(parts...)
+	clean := filepath.Clean(joined)
+	if filepath.IsAbs(clean) {
+		clean = strings.TrimPrefix(clean, string(filepath.Separator))
+	}
+	full := filepath.Join(base, clean)
+	rel, err := filepath.Rel(base, full)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("outside base")
+	}
+	return full, nil
+}

--- a/file-engine/internal/adapters/fs/local/local.go
+++ b/file-engine/internal/adapters/fs/local/local.go
@@ -1,122 +1,96 @@
 package local
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "io"
-    "os"
-    "path/filepath"
-    "strings"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	fsadapter "github.com/example/file-engine/internal/adapters/fs"
 )
 
 type LocalFs struct {
-    BaseRoot string
+	BaseRoot string
 }
 
 func NewLocalFs(base string) (*LocalFs, error) {
-    if base == "" {
-        return nil, errors.New("base required")
-    }
-    abs, err := filepath.Abs(base)
-    if err != nil {
-        return nil, err
-    }
-    return &LocalFs{BaseRoot: filepath.Clean(abs)}, nil
+	if base == "" {
+		return nil, errors.New("base required")
+	}
+	abs, err := filepath.Abs(base)
+	if err != nil {
+		return nil, err
+	}
+	return &LocalFs{BaseRoot: filepath.Clean(abs)}, nil
 }
 
 func (l *LocalFs) sanitizeAndJoin(parts ...string) (string, error) {
-    joined := filepath.Join(parts...)
-    clean := filepath.Clean(joined)
-    if filepath.IsAbs(clean) {
-        clean = strings.TrimPrefix(clean, string(os.PathSeparator))
-    }
-    full := filepath.Join(l.BaseRoot, clean)
-    rel, err := filepath.Rel(l.BaseRoot, full)
-    if err != nil {
-        return "", err
-    }
-    if strings.HasPrefix(rel, "..") {
-        return "", fmt.Errorf("outside base")
-    }
-    return full, nil
+	return fsadapter.SafeJoin(l.BaseRoot, parts...)
 }
 
 func (l *LocalFs) CreateFolder(ctx context.Context, parts ...string) error {
-    full, err := l.sanitizeAndJoin(parts...)
-    if err != nil {
-        return err
-    }
-    return os.MkdirAll(full, 0o755)
+	full, err := l.sanitizeAndJoin(parts...)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(full, 0o755)
 }
 
 func (l *LocalFs) AtomicWriteFile(ctx context.Context, perm uint32, data []byte, parts ...string) error {
-    full, err := l.sanitizeAndJoin(parts...)
-    if err != nil {
-        return err
-    }
-    dir := filepath.Dir(full)
-    if err := os.MkdirAll(dir, 0o755); err != nil {
-        return err
-    }
-    tmp, err := os.CreateTemp(dir, ".tmp-*")
-    if err != nil {
-        return err
-    }
-    if _, err := tmp.Write(data); err != nil {
-        tmp.Close()
-        return err
-    }
-    tmp.Close()
-    if err := os.Chmod(tmp.Name(), os.FileMode(perm)); err != nil {
-        return err
-    }
-    return os.Rename(tmp.Name(), full)
+	full, err := l.sanitizeAndJoin(parts...)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(full)
+	_ = dir
+	return fsadapter.AtomicWriteFile(full, os.FileMode(perm), bytes.NewReader(data))
 }
 
 func (l *LocalFs) MoveUploadedFile(ctx context.Context, src []string, dst []string) error {
-    srcF, err := l.sanitizeAndJoin(src...)
-    if err != nil {
-        return err
-    }
-    dstF, err := l.sanitizeAndJoin(dst...)
-    if err != nil {
-        return err
-    }
-    if err := os.MkdirAll(filepath.Dir(dstF), 0o755); err != nil {
-        return err
-    }
-    if err := os.Rename(srcF, dstF); err == nil {
-        return nil
-    }
-    // fallback copy
-    in, err := os.Open(srcF)
-    if err != nil {
-        return err
-    }
-    defer in.Close()
-    out, err := os.Create(dstF)
-    if err != nil {
-        return err
-    }
-    defer out.Close()
-    if _, err := io.Copy(out, in); err != nil {
-        return err
-    }
-    return os.Remove(srcF)
+	srcF, err := l.sanitizeAndJoin(src...)
+	if err != nil {
+		return err
+	}
+	dstF, err := l.sanitizeAndJoin(dst...)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dstF), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(srcF, dstF); err == nil {
+		return nil
+	}
+	// fallback copy
+	in, err := os.Open(srcF)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dstF)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return os.Remove(srcF)
 }
 
 func (l *LocalFs) Exists(parts ...string) (bool, error) {
-    full, err := l.sanitizeAndJoin(parts...)
-    if err != nil {
-        return false, err
-    }
-    _, err = os.Stat(full)
-    if err == nil {
-        return true, nil
-    }
-    if os.IsNotExist(err) {
-        return false, nil
-    }
-    return false, err
+	full, err := l.sanitizeAndJoin(parts...)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(full)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/file-engine/internal/adapters/queue/redisq/redisq.go
+++ b/file-engine/internal/adapters/queue/redisq/redisq.go
@@ -61,6 +61,11 @@ func (q *RedisQueue) Pop(ctx context.Context) (*TaskPayload, error) {
 		return nil, err
 	}
 	q.observeQueueDepth(ctx, t.ID, t.Params["correlation_id"])
+	if enqRaw := t.Params["enqueued_at_unix_nano"]; enqRaw != "" {
+		if enq, err := strconv.ParseInt(enqRaw, 10, 64); err == nil {
+			observability.DefaultMetrics.ObserveQueueLagMs(time.Since(time.Unix(0, enq)).Milliseconds())
+		}
+	}
 	return &t, nil
 }
 
@@ -130,6 +135,7 @@ func (q *RedisQueue) observeQueueDepth(ctx context.Context, taskID, correlationI
 			"event":          "queue.depth.alert",
 			"task_id":        taskID,
 			"correlation_id": correlationID,
+			"request_id":     correlationID,
 			"queue_depth":    depth,
 			"threshold":      q.queueAlertThreshold,
 		})
@@ -147,6 +153,7 @@ func (q *RedisQueue) EnqueueCreateFolder(ctx context.Context, parentPath, folder
 			"name":           folderName,
 			"by":             requestedBy,
 			"correlation_id": correlationID,
+			"request_id":     correlationID,
 		},
 	}
 	if err := q.Enqueue(ctx, p); err != nil {

--- a/file-engine/internal/adapters/security/malware_scanner_stub.go
+++ b/file-engine/internal/adapters/security/malware_scanner_stub.go
@@ -1,0 +1,19 @@
+package security
+
+import (
+	"context"
+	"strings"
+
+	"github.com/example/file-engine/internal/app/ports"
+)
+
+type MalwareScannerStub struct{}
+
+func NewMalwareScannerStub() *MalwareScannerStub { return &MalwareScannerStub{} }
+
+func (s *MalwareScannerStub) Scan(_ context.Context, stagedPath string) (ports.MalwareScanResult, error) {
+	if strings.Contains(strings.ToLower(stagedPath), "eicar") {
+		return ports.MalwareScanResult{Status: ports.MalwareStatusInfected, Engine: "stub-av", Detail: "signature matched"}, nil
+	}
+	return ports.MalwareScanResult{Status: ports.MalwareStatusClean, Engine: "stub-av", Detail: "no threats detected"}, nil
+}

--- a/file-engine/internal/app/ports/malware_scanner.port.go
+++ b/file-engine/internal/app/ports/malware_scanner.port.go
@@ -1,0 +1,22 @@
+package ports
+
+import "context"
+
+type MalwareScanStatus string
+
+const (
+	MalwareStatusClean       MalwareScanStatus = "clean"
+	MalwareStatusInfected    MalwareScanStatus = "infected"
+	MalwareStatusUnknown     MalwareScanStatus = "unknown"
+	MalwareStatusQuarantined MalwareScanStatus = "quarantined"
+)
+
+type MalwareScanResult struct {
+	Status MalwareScanStatus
+	Engine string
+	Detail string
+}
+
+type MalwareScanner interface {
+	Scan(ctx context.Context, stagedPath string) (MalwareScanResult, error)
+}

--- a/file-engine/internal/app/tasks/audit_emitters.go
+++ b/file-engine/internal/app/tasks/audit_emitters.go
@@ -1,0 +1,98 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/observability"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type auditEventRecord struct {
+	Event         string            `json:"event"`
+	TaskID        string            `json:"task_id,omitempty"`
+	CorrelationID string            `json:"correlation_id,omitempty"`
+	Message       string            `json:"message,omitempty"`
+	CreatedAt     time.Time         `json:"created_at"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+}
+
+type postgresAuditEmitter struct {
+	pool *pgxpool.Pool
+	log  *logger.Logger
+}
+
+func (e *postgresAuditEmitter) EmitTaskEvent(ctx context.Context, event, taskID, correlationID, message string) {
+	if e.pool == nil {
+		return
+	}
+	metadata := map[string]string{"source": "file-engine-worker"}
+	metaJSON, err := json.Marshal(metadata)
+	if err != nil {
+		e.log.Event("warn", "audit metadata marshal failed", map[string]any{"event": event, "task_id": taskID, "error": err.Error()})
+		return
+	}
+	if _, err := e.pool.Exec(ctx,
+		`INSERT INTO audit_events (event_type, task_id, correlation_id, message, metadata) VALUES ($1,$2,$3,$4,$5::jsonb)`,
+		event, taskID, correlationID, message, string(metaJSON),
+	); err != nil {
+		e.log.Event("warn", "audit persistence failed", map[string]any{"event": event, "task_id": taskID, "error": err.Error()})
+		observability.DefaultMetrics.IncAuditSinkFailure()
+		return
+	}
+	observability.DefaultMetrics.IncAuditEventEmitted()
+}
+
+type sinkAuditEmitter struct {
+	sink ImmutableSink
+	log  *logger.Logger
+}
+
+func (e *sinkAuditEmitter) EmitTaskEvent(ctx context.Context, event, taskID, correlationID, message string) {
+	rec := auditEventRecord{
+		Event:         event,
+		TaskID:        taskID,
+		CorrelationID: correlationID,
+		Message:       message,
+		CreatedAt:     time.Now().UTC(),
+		Metadata:      map[string]string{"source": "file-engine-worker", "sink": e.sink.Type()},
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		e.log.Event("warn", "immutable audit marshal failed", map[string]any{"event": event, "task_id": taskID, "error": err.Error()})
+		return
+	}
+	if err := e.sink.WriteLine(ctx, b); err != nil {
+		e.log.Event("warn", "immutable sink emission failed", map[string]any{"event": event, "task_id": taskID, "error": err.Error(), "sink": e.sink.Type()})
+		observability.DefaultMetrics.IncAuditSinkFailure()
+		return
+	}
+	observability.DefaultMetrics.IncAuditEventEmitted()
+}
+
+type multiAuditEmitter struct {
+	emitters []AuditEmitter
+}
+
+func (m *multiAuditEmitter) EmitTaskEvent(ctx context.Context, event, taskID, correlationID, message string) {
+	for _, e := range m.emitters {
+		e.EmitTaskEvent(ctx, event, taskID, correlationID, message)
+	}
+}
+
+func NewDualLayerAuditEmitter(logg *logger.Logger, pool *pgxpool.Pool, immutableSinkPath string) AuditEmitter {
+	emitters := []AuditEmitter{&logAuditEmitter{log: logg}}
+	if pool != nil {
+		emitters = append(emitters, &postgresAuditEmitter{pool: pool, log: logg})
+	}
+	if sink := BuildImmutableSinkFromEnv(logg, strings.TrimSpace(immutableSinkPath)); sink != nil {
+		emitters = append(emitters, &sinkAuditEmitter{sink: sink, log: logg})
+	}
+	if len(emitters) == 1 {
+		return emitters[0]
+	}
+	return &multiAuditEmitter{emitters: emitters}
+}

--- a/file-engine/internal/app/tasks/audit_emitters_test.go
+++ b/file-engine/internal/app/tasks/audit_emitters_test.go
@@ -1,0 +1,37 @@
+package tasks
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/example/file-engine/internal/logger"
+)
+
+func TestNewDualLayerAuditEmitterWithNoOptionalSinksFallsBackToLog(t *testing.T) {
+	a := NewDualLayerAuditEmitter(logger.New("debug"), nil, "")
+	if _, ok := a.(*logAuditEmitter); !ok {
+		t.Fatalf("expected log audit emitter fallback, got %T", a)
+	}
+}
+
+func TestNewDualLayerAuditEmitterWritesToImmutableSink(t *testing.T) {
+	t.Parallel()
+	p := t.TempDir() + "/audit.ndjson"
+
+	a := NewDualLayerAuditEmitter(logger.New("debug"), nil, p)
+	a.EmitTaskEvent(context.Background(), "task.succeeded", "task-1", "corr-1", "ok")
+
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read immutable sink: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"event":"task.succeeded"`) {
+		t.Fatalf("expected event in sink, got %q", got)
+	}
+	if !strings.Contains(got, `"task_id":"task-1"`) {
+		t.Fatalf("expected task id in sink, got %q", got)
+	}
+}

--- a/file-engine/internal/app/tasks/audit_sinks.go
+++ b/file-engine/internal/app/tasks/audit_sinks.go
@@ -1,0 +1,253 @@
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/observability"
+)
+
+type ImmutableSink interface {
+	WriteLine(ctx context.Context, line []byte) error
+	Type() string
+}
+
+type DeadLetterWriter interface {
+	Write(ctx context.Context, envelope deadLetterEnvelope) error
+}
+
+type deadLetterEnvelope struct {
+	SinkType    string    `json:"sink_type"`
+	Error       string    `json:"error"`
+	PayloadLine string    `json:"payload_line"`
+	FailedAt    time.Time `json:"failed_at"`
+}
+
+type fileImmutableSink struct {
+	path string
+	mu   sync.Mutex
+}
+
+func (s *fileImmutableSink) Type() string { return "file" }
+
+func (s *fileImmutableSink) WriteLine(_ context.Context, line []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(s.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+type localBucketSink struct {
+	rootDir string
+	bucket  string
+	prefix  string
+	mu      sync.Mutex
+}
+
+func (s *localBucketSink) Type() string { return "bucket" }
+
+func (s *localBucketSink) WriteLine(_ context.Context, line []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	dir := filepath.Join(s.rootDir, s.bucket, s.prefix)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	name := fmt.Sprintf("audit-%d.jsonl", time.Now().UTC().UnixNano())
+	path := filepath.Join(dir, name)
+	return os.WriteFile(path, append(line, '\n'), 0o600)
+}
+
+type lokiSink struct {
+	endpoint string
+	client   *http.Client
+}
+
+func (s *lokiSink) Type() string { return "loki" }
+
+func (s *lokiSink) WriteLine(ctx context.Context, line []byte) error {
+	payload := map[string]any{
+		"streams": []map[string]any{{
+			"stream": map[string]string{"service": "file-engine", "source": "audit"},
+			"values": [][]string{{strconv.FormatInt(time.Now().UTC().UnixNano(), 10), string(line)}},
+		}},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("loki returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+type fileDeadLetterWriter struct {
+	path string
+	mu   sync.Mutex
+}
+
+func (w *fileDeadLetterWriter) Write(_ context.Context, envelope deadLetterEnvelope) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(w.path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	b, err := json.Marshal(envelope)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+type retryingSink struct {
+	sink            ImmutableSink
+	deadLetter      DeadLetterWriter
+	log             *logger.Logger
+	attempts        int
+	retryDelay      time.Duration
+	retryMultiplier float64
+}
+
+func (s *retryingSink) Type() string { return s.sink.Type() }
+
+func (s *retryingSink) WriteLine(ctx context.Context, line []byte) error {
+	attempts := s.attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	delay := s.retryDelay
+	if delay <= 0 {
+		delay = 25 * time.Millisecond
+	}
+	mult := s.retryMultiplier
+	if mult < 1 {
+		mult = 2
+	}
+	var err error
+	for i := 1; i <= attempts; i++ {
+		err = s.sink.WriteLine(ctx, line)
+		if err == nil {
+			return nil
+		}
+		if i < attempts {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			delay = time.Duration(float64(delay) * mult)
+		}
+	}
+	if s.deadLetter != nil {
+		if dlErr := s.deadLetter.Write(ctx, deadLetterEnvelope{SinkType: s.sink.Type(), Error: err.Error(), PayloadLine: string(line), FailedAt: time.Now().UTC()}); dlErr == nil {
+			observability.DefaultMetrics.IncAuditDeadLetter()
+		}
+	}
+	if s.log != nil {
+		s.log.Event("warn", "immutable sink failed after retries", map[string]any{"sink": s.sink.Type(), "error": err.Error()})
+	}
+	return err
+}
+
+func BuildImmutableSinkFromEnv(logg *logger.Logger, legacyPath string) ImmutableSink {
+	sinkType := strings.TrimSpace(os.Getenv("AUDIT_IMMUTABLE_SINK_TYPE"))
+	if sinkType == "" && strings.TrimSpace(legacyPath) != "" {
+		sinkType = "file"
+	}
+
+	var base ImmutableSink
+	switch strings.ToLower(sinkType) {
+	case "file":
+		p := strings.TrimSpace(legacyPath)
+		if p == "" {
+			p = strings.TrimSpace(os.Getenv("AUDIT_IMMUTABLE_SINK_PATH"))
+		}
+		if p == "" {
+			return nil
+		}
+		base = &fileImmutableSink{path: p}
+	case "bucket":
+		bucket := strings.TrimSpace(os.Getenv("AUDIT_BUCKET_NAME"))
+		if bucket == "" {
+			return nil
+		}
+		root := strings.TrimSpace(os.Getenv("AUDIT_BUCKET_LOCAL_DIR"))
+		if root == "" {
+			root = filepath.Join(os.TempDir(), "audit-bucket")
+		}
+		base = &localBucketSink{rootDir: root, bucket: bucket, prefix: strings.TrimSpace(os.Getenv("AUDIT_BUCKET_PREFIX"))}
+	case "loki":
+		endpoint := strings.TrimSpace(os.Getenv("AUDIT_LOKI_ENDPOINT"))
+		if endpoint == "" {
+			return nil
+		}
+		base = &lokiSink{endpoint: endpoint, client: &http.Client{Timeout: 5 * time.Second}}
+	default:
+		return nil
+	}
+
+	attempts := 3
+	if v := strings.TrimSpace(os.Getenv("AUDIT_SINK_RETRY_ATTEMPTS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			attempts = n
+		}
+	}
+	delay := 50 * time.Millisecond
+	if v := strings.TrimSpace(os.Getenv("AUDIT_SINK_RETRY_DELAY_MS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			delay = time.Duration(n) * time.Millisecond
+		}
+	}
+	dlPath := strings.TrimSpace(os.Getenv("AUDIT_DEAD_LETTER_PATH"))
+	if dlPath == "" {
+		dlPath = filepath.Join(os.TempDir(), "file-engine-audit-deadletter.ndjson")
+	}
+
+	return &retryingSink{
+		sink:            base,
+		deadLetter:      &fileDeadLetterWriter{path: dlPath},
+		log:             logg,
+		attempts:        attempts,
+		retryDelay:      delay,
+		retryMultiplier: 2,
+	}
+}

--- a/file-engine/internal/app/tasks/audit_sinks_test.go
+++ b/file-engine/internal/app/tasks/audit_sinks_test.go
@@ -1,0 +1,114 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/observability"
+)
+
+type flakySink struct {
+	fails int
+}
+
+func (f *flakySink) Type() string { return "flaky" }
+
+func (f *flakySink) WriteLine(_ context.Context, _ []byte) error {
+	if f.fails > 0 {
+		f.fails--
+		return errors.New("boom")
+	}
+	return nil
+}
+
+func TestRetryingSinkWritesDeadLetterAfterExhaustingRetries(t *testing.T) {
+	t.Parallel()
+	orig := observability.DefaultMetrics
+	observability.DefaultMetrics = observability.NewMetrics()
+	t.Cleanup(func() { observability.DefaultMetrics = orig })
+
+	dl := filepath.Join(t.TempDir(), "deadletter.ndjson")
+	r := &retryingSink{
+		sink:            &flakySink{fails: 3},
+		deadLetter:      &fileDeadLetterWriter{path: dl},
+		log:             logger.New("debug"),
+		attempts:        2,
+		retryDelay:      1 * time.Millisecond,
+		retryMultiplier: 1,
+	}
+
+	err := r.WriteLine(context.Background(), []byte(`{"event":"x"}`))
+	if err == nil {
+		t.Fatalf("expected write to fail")
+	}
+	b, readErr := os.ReadFile(dl)
+	if readErr != nil {
+		t.Fatalf("read dead letter file: %v", readErr)
+	}
+	if !strings.Contains(string(b), `"sink_type":"flaky"`) {
+		t.Fatalf("expected dead letter sink type, got %q", string(b))
+	}
+	snapshot := observability.DefaultMetrics.SnapshotPrometheus()
+	if !strings.Contains(snapshot, "fileengine_audit_dead_letters_total 1") {
+		t.Fatalf("expected dead-letter metric increment, snapshot=%s", snapshot)
+	}
+}
+
+func TestBuildImmutableSinkFromEnvBucketWritesJSONL(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AUDIT_IMMUTABLE_SINK_TYPE", "bucket")
+	t.Setenv("AUDIT_BUCKET_NAME", "audit-bucket")
+	t.Setenv("AUDIT_BUCKET_PREFIX", "events")
+	t.Setenv("AUDIT_BUCKET_LOCAL_DIR", root)
+	t.Setenv("AUDIT_DEAD_LETTER_PATH", filepath.Join(root, "dlq.ndjson"))
+
+	s := BuildImmutableSinkFromEnv(logger.New("debug"), "")
+	if s == nil {
+		t.Fatalf("expected bucket sink")
+	}
+	if err := s.WriteLine(context.Background(), []byte(`{"event":"bucket"}`)); err != nil {
+		t.Fatalf("write line: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "audit-bucket", "events", "*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected bucket jsonl object to be created")
+	}
+}
+
+func TestBuildImmutableSinkFromEnvLokiPostsLine(t *testing.T) {
+	received := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		b, _ := io.ReadAll(r.Body)
+		received = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	t.Setenv("AUDIT_IMMUTABLE_SINK_TYPE", "loki")
+	t.Setenv("AUDIT_LOKI_ENDPOINT", srv.URL)
+	t.Setenv("AUDIT_DEAD_LETTER_PATH", filepath.Join(t.TempDir(), "dlq.ndjson"))
+
+	s := BuildImmutableSinkFromEnv(logger.New("debug"), "")
+	if s == nil {
+		t.Fatalf("expected loki sink")
+	}
+	if err := s.WriteLine(context.Background(), []byte(`{"event":"loki"}`)); err != nil {
+		t.Fatalf("write line: %v", err)
+	}
+	if !strings.Contains(received, "streams") {
+		t.Fatalf("expected loki payload, got %q", received)
+	}
+}

--- a/file-engine/internal/app/tasks/worker.go
+++ b/file-engine/internal/app/tasks/worker.go
@@ -37,6 +37,7 @@ func (l *logAuditEmitter) EmitTaskEvent(_ context.Context, event, taskID, correl
 		"event":          event,
 		"task_id":        taskID,
 		"correlation_id": correlationID,
+		"request_id":     correlationID,
 		"audit_message":  message,
 	})
 }
@@ -102,15 +103,20 @@ func (w *Worker) Start(ctx context.Context) {
 			continue
 		}
 		correlationID := task.Params["correlation_id"]
+		if correlationID == "" {
+			correlationID = task.Params["request_id"]
+		}
+		w.auditor.EmitTaskEvent(ctx, "task.dequeued", task.ID, correlationID, fmt.Sprintf("task_type=%s", task.Type))
 		w.auditor.EmitTaskEvent(ctx, "task.processing", task.ID, correlationID, fmt.Sprintf("task_type=%s", task.Type))
 		w.log.Event("info", "worker task processing", map[string]any{
 			"event":          "task.processing",
 			"task_id":        task.ID,
 			"correlation_id": correlationID,
+			"request_id":     correlationID,
 			"task_type":      task.Type,
 		})
 		if err := w.persistStatus(ctx, task.ID, "running", correlationID, "task is running"); err != nil {
-			w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": err.Error()})
+			w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "request_id": correlationID, "error": err.Error()})
 		}
 
 		processCtx := ctx
@@ -126,18 +132,24 @@ func (w *Worker) Start(ctx context.Context) {
 			if errors.Is(err, context.DeadlineExceeded) {
 				msg = fmt.Sprintf("task processing timed out after %s", w.taskProcessTimeout)
 			}
-			w.log.Event("warn", "worker task failed", map[string]any{"event": "task.failed", "task_id": task.ID, "correlation_id": correlationID, "error": msg})
+			w.log.Event("warn", "worker task failed", map[string]any{"event": "task.failed", "task_id": task.ID, "correlation_id": correlationID, "request_id": correlationID, "error": msg})
 			if completeErr := w.persistStatus(ctx, task.ID, "failed", correlationID, msg); completeErr != nil {
-				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": completeErr.Error()})
+				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "request_id": correlationID, "error": completeErr.Error()})
 			}
 			w.auditor.EmitTaskEvent(ctx, "task.failed", task.ID, correlationID, msg)
+			if task.Type == "create_folder" {
+				w.auditor.EmitTaskEvent(ctx, "folder.mutation.failed", task.ID, correlationID, msg)
+			}
 			w.maybeAlertOnFailures(correlationID)
 		} else {
-			w.log.Event("info", "worker task succeeded", map[string]any{"event": "task.succeeded", "task_id": task.ID, "correlation_id": correlationID})
+			w.log.Event("info", "worker task succeeded", map[string]any{"event": "task.succeeded", "task_id": task.ID, "correlation_id": correlationID, "request_id": correlationID})
 			if completeErr := w.persistStatus(ctx, task.ID, "success", correlationID, "folder created"); completeErr != nil {
-				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "error": completeErr.Error()})
+				w.log.Event("warn", "task status update failed", map[string]any{"event": "task.status_update_failed", "task_id": task.ID, "correlation_id": correlationID, "request_id": correlationID, "error": completeErr.Error()})
 			}
 			w.auditor.EmitTaskEvent(ctx, "task.succeeded", task.ID, correlationID, "task completed")
+			if task.Type == "create_folder" {
+				w.auditor.EmitTaskEvent(ctx, "folder.mutation.succeeded", task.ID, correlationID, "folder created")
+			}
 		}
 	}
 }
@@ -186,6 +198,7 @@ func (w *Worker) maybeAlertOnFailures(correlationID string) {
 		w.log.Event("warn", "task failure alert threshold reached", map[string]any{
 			"event":           "task.failure.alert",
 			"correlation_id":  correlationID,
+			"request_id":      correlationID,
 			"failed_tasks":    total,
 			"alert_threshold": w.failureAlertThreshold,
 		})

--- a/file-engine/internal/auth/tenant_resolver.go
+++ b/file-engine/internal/auth/tenant_resolver.go
@@ -2,8 +2,11 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TenantResolver is the server-side source-of-truth for tenant membership.
@@ -51,6 +54,60 @@ func (r *InMemoryTenantResolver) UserHasTenant(_ context.Context, userID, tenant
 	set := r.memberships[userID]
 	_, ok := set[tenantID]
 	return ok, nil
+}
+
+type PostgresTenantResolver struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostgresTenantResolver(pool *pgxpool.Pool) *PostgresTenantResolver {
+	return &PostgresTenantResolver{pool: pool}
+}
+
+func (r *PostgresTenantResolver) ResolveTenants(ctx context.Context, userID string) ([]string, error) {
+	if r.pool == nil {
+		return nil, fmt.Errorf("postgres tenant resolver not configured")
+	}
+	rows, err := r.pool.Query(ctx,
+		`SELECT tenant_id FROM user_tenants WHERE user_id = $1 ORDER BY tenant_id ASC`,
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query user_tenants: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]string, 0)
+	for rows.Next() {
+		var tenantID string
+		if err := rows.Scan(&tenantID); err != nil {
+			return nil, fmt.Errorf("scan tenant_id: %w", err)
+		}
+		out = append(out, tenantID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tenants: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func (r *PostgresTenantResolver) UserHasTenant(ctx context.Context, userID, tenantID string) (bool, error) {
+	if r.pool == nil {
+		return false, fmt.Errorf("postgres tenant resolver not configured")
+	}
+	var exists bool
+	err := r.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM user_tenants WHERE user_id = $1 AND tenant_id = $2)`,
+		userID,
+		tenantID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("query membership: %w", err)
+	}
+	return exists, nil
 }
 
 // DenyAllTenantResolver is the secure default when source-of-truth mappings are unavailable.

--- a/file-engine/internal/auth/tenant_resolver_test.go
+++ b/file-engine/internal/auth/tenant_resolver_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -44,5 +45,21 @@ func TestDenyAllTenantResolver(t *testing.T) {
 	}
 	if ok {
 		t.Fatal("deny-all resolver must deny tenant membership")
+	}
+}
+
+func TestPostgresTenantResolverNilPool(t *testing.T) {
+	r := NewPostgresTenantResolver(nil)
+	_, err := r.ResolveTenants(context.Background(), "alice")
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("expected not configured error, got %v", err)
+	}
+
+	ok, err := r.UserHasTenant(context.Background(), "alice", "acme")
+	if err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("expected not configured error, got %v", err)
+	}
+	if ok {
+		t.Fatalf("expected false membership when resolver is not configured")
 	}
 }

--- a/file-engine/internal/di/container.go
+++ b/file-engine/internal/di/container.go
@@ -3,12 +3,16 @@ package di
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/example/file-engine/internal/adapters/queue/redisq"
+	adaptersecurity "github.com/example/file-engine/internal/adapters/security"
+	"github.com/example/file-engine/internal/app/tasks"
 	"github.com/example/file-engine/internal/auth"
 	"github.com/example/file-engine/internal/config"
 	"github.com/example/file-engine/internal/handlers"
@@ -35,6 +39,7 @@ func BuildContainer(cfg *config.Config, logg *logger.Logger) *Container {
 func (c *Container) Servers() *Servers {
 	rdb := redis.NewClient(&redis.Options{Addr: c.Config.RedisAddr})
 	q := redisq.NewRedisQueue(rdb)
+	var pgPool *pgxpool.Pool
 
 	// Storage backend (same as worker)
 	st, err := storagefactory.NewFromConfig(context.Background(), storagefactory.Config{
@@ -60,6 +65,7 @@ func (c *Container) Servers() *Servers {
 		if err != nil {
 			c.Logger.Fatalf("pg pool: %v", err)
 		}
+		pgPool = pool
 		aclStore = auth.NewPostgresACLStore(pool)
 	} else {
 		aclStore = auth.NewInMemoryACLStore()
@@ -70,18 +76,44 @@ func (c *Container) Servers() *Servers {
 		c.Logger.Fatalf("jwt verifier: %v", err)
 	}
 
-	tenantResolver := buildTenantResolverFromEnv()
+	tenantResolver := buildTenantResolver(pgPool)
+	auditor := tasks.NewDualLayerAuditEmitter(c.Logger, pgPool, getenv("AUDIT_IMMUTABLE_SINK_PATH"))
 
 	objSvc := services.NewObjectService(st)
-	grpcHandler := handlers.NewGRPCHandler(q, objSvc, aclStore, tenantResolver, c.Logger)
+	uploadSvc := services.NewUploadService(st, adaptersecurity.NewMalwareScannerStub(), services.UploadPolicy{
+		MaxObjectSizeBytes: envInt64("UPLOAD_MAX_OBJECT_SIZE_BYTES", 10*1024*1024),
+		TenantQuotaBytes:   envInt64("UPLOAD_TENANT_QUOTA_BYTES", 100*1024*1024),
+		RequestTimeout:     time.Duration(envInt64("UPLOAD_REQUEST_TIMEOUT_MS", 30000)) * time.Millisecond,
+		RequireCleanScan:   strings.EqualFold(getenv("UPLOAD_REQUIRE_CLEAN_SCAN"), "true"),
+	})
+	grpcHandler := handlers.NewGRPCHandler(q, objSvc, uploadSvc, aclStore, tenantResolver, c.Logger, auditor)
 
 	grpcSrv := server.NewGRPCServer(c.Config.GRPCAddr, c.Logger, verifier, aclStore, grpcHandler)
-	httpSrv := server.NewHTTPServer(c.Config.HTTPAddr, c.Config.GRPCAddr, c.Logger, verifier, st, aclStore)
+	httpSrv := server.NewHTTPServer(c.Config.HTTPAddr, c.Config.GRPCAddr, c.Logger, verifier, st, aclStore, uploadSvc)
+	httpSrv.AddReadyCheck("storage", func(ctx context.Context) error {
+		_, err := st.List(ctx, "/")
+		return err
+	})
+	httpSrv.AddReadyCheck("queue", func(ctx context.Context) error {
+		return rdb.Ping(ctx).Err()
+	})
+	if pgPool != nil {
+		httpSrv.AddReadyCheck("postgres", func(ctx context.Context) error {
+			if err := pgPool.Ping(ctx); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
 
 	return &Servers{GRPC: grpcSrv, HTTP: httpSrv}
 }
 
-func buildTenantResolverFromEnv() auth.TenantResolver {
+func buildTenantResolver(pool *pgxpool.Pool) auth.TenantResolver {
+	if pool != nil {
+		return auth.NewPostgresTenantResolver(pool)
+	}
+
 	raw := strings.TrimSpace(getenv("TENANT_MEMBERSHIPS"))
 	if raw == "" {
 		return auth.NewDenyAllTenantResolver()
@@ -106,4 +138,16 @@ func buildTenantResolverFromEnv() auth.TenantResolver {
 
 func getenv(k string) string {
 	return os.Getenv(k)
+}
+
+func envInt64(k string, d int64) int64 {
+	v := strings.TrimSpace(getenv(k))
+	if v == "" {
+		return d
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return d
+	}
+	return n
 }

--- a/file-engine/internal/di/container_test.go
+++ b/file-engine/internal/di/container_test.go
@@ -1,0 +1,47 @@
+package di
+
+import (
+	"os"
+	"testing"
+
+	"github.com/example/file-engine/internal/auth"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestBuildTenantResolverUsesPostgresWhenPoolConfigured(t *testing.T) {
+	resolver := buildTenantResolver(&pgxpool.Pool{})
+	if _, ok := resolver.(*auth.PostgresTenantResolver); !ok {
+		t.Fatalf("expected postgres tenant resolver, got %T", resolver)
+	}
+}
+
+func TestBuildTenantResolverFallsBackToDenyAllWithoutConfig(t *testing.T) {
+	prev := os.Getenv("TENANT_MEMBERSHIPS")
+	t.Cleanup(func() { _ = os.Setenv("TENANT_MEMBERSHIPS", prev) })
+	_ = os.Unsetenv("TENANT_MEMBERSHIPS")
+
+	resolver := buildTenantResolver(nil)
+	if _, ok := resolver.(*auth.DenyAllTenantResolver); !ok {
+		t.Fatalf("expected deny-all tenant resolver, got %T", resolver)
+	}
+}
+
+func TestBuildTenantResolverFallsBackToInMemoryWhenEnvConfigured(t *testing.T) {
+	prev := os.Getenv("TENANT_MEMBERSHIPS")
+	t.Cleanup(func() { _ = os.Setenv("TENANT_MEMBERSHIPS", prev) })
+	_ = os.Setenv("TENANT_MEMBERSHIPS", "alice=acme,beta")
+
+	resolver := buildTenantResolver(nil)
+	inmem, ok := resolver.(*auth.InMemoryTenantResolver)
+	if !ok {
+		t.Fatalf("expected in-memory tenant resolver, got %T", resolver)
+	}
+
+	okHas, err := inmem.UserHasTenant(t.Context(), "alice", "beta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !okHas {
+		t.Fatalf("expected membership to be loaded from TENANT_MEMBERSHIPS")
+	}
+}

--- a/file-engine/internal/handlers/grpc_handler.go
+++ b/file-engine/internal/handlers/grpc_handler.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"path"
@@ -12,6 +15,7 @@ import (
 	"github.com/example/file-engine/internal/auth"
 	"github.com/example/file-engine/internal/authz"
 	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/observability"
 	"github.com/example/file-engine/internal/services"
 	pb "github.com/example/file-engine/pkg/generated"
 	"google.golang.org/grpc/codes"
@@ -30,19 +34,32 @@ type GRPCHandler struct {
 
 	queue          TaskQueue
 	objects        *services.ObjectService
+	uploads        *services.UploadService
 	acl            auth.ACLStore
 	tenantResolver auth.TenantResolver
 	log            *logger.Logger
+	auditor        AuditEmitter
 }
 
-func NewGRPCHandler(q TaskQueue, obj *services.ObjectService, acl auth.ACLStore, tenantResolver auth.TenantResolver, logg *logger.Logger) *GRPCHandler {
+type AuditEmitter interface {
+	EmitTaskEvent(ctx context.Context, event, taskID, correlationID, message string)
+}
+
+type noopAuditEmitter struct{}
+
+func (noopAuditEmitter) EmitTaskEvent(context.Context, string, string, string, string) {}
+
+func NewGRPCHandler(q TaskQueue, obj *services.ObjectService, uploads *services.UploadService, acl auth.ACLStore, tenantResolver auth.TenantResolver, logg *logger.Logger, auditor AuditEmitter) *GRPCHandler {
 	if tenantResolver == nil {
 		tenantResolver = auth.NewDenyAllTenantResolver()
 	}
 	if logg == nil {
 		logg = logger.New("info")
 	}
-	return &GRPCHandler{queue: q, objects: obj, acl: acl, tenantResolver: tenantResolver, log: logg}
+	if auditor == nil {
+		auditor = noopAuditEmitter{}
+	}
+	return &GRPCHandler{queue: q, objects: obj, uploads: uploads, acl: acl, tenantResolver: tenantResolver, log: logg, auditor: auditor}
 }
 
 // CreateFolder stays async via task queue (worker executes).
@@ -62,11 +79,14 @@ func (h *GRPCHandler) CreateFolder(ctx context.Context, req *pb.CreateFolderRequ
 	}
 	allowed, err := h.tenantResolver.UserHasTenant(ctx, authCtx.UserID, tenantID)
 	if err != nil {
+		h.auditor.EmitTaskEvent(ctx, "auth.decision.error", "", correlationIDFromContext(ctx), "tenant resolution failed")
 		return nil, status.Error(codes.Internal, "tenant resolution failed")
 	}
 	if !allowed {
+		h.auditor.EmitTaskEvent(ctx, "auth.decision.denied", "", correlationIDFromContext(ctx), "tenant access denied")
 		return nil, status.Error(codes.PermissionDenied, "tenant access denied")
 	}
+	h.auditor.EmitTaskEvent(ctx, "auth.decision.allowed", "", correlationIDFromContext(ctx), "tenant access allowed")
 
 	correlationID := correlationIDFromContext(ctx)
 	requestedBy := req.RequestedBy
@@ -90,6 +110,8 @@ func (h *GRPCHandler) CreateFolder(ctx context.Context, req *pb.CreateFolderRequ
 	if err != nil {
 		return nil, err
 	}
+	h.auditor.EmitTaskEvent(ctx, "task.enqueued", taskID, correlationID, "create_folder queued")
+	h.auditor.EmitTaskEvent(ctx, "folder.mutation.requested", taskID, correlationID, "create_folder requested")
 	h.log.Event("info", "create folder task queued", map[string]any{
 		"event":          "task.queued",
 		"request":        "create_folder",
@@ -204,13 +226,35 @@ func (h *GRPCHandler) ListObjects(ctx context.Context, req *pb.ListObjectsReques
 }
 
 func (h *GRPCHandler) UploadObject(ctx context.Context, req *pb.UploadObjectRequest) (*pb.UploadObjectResponse, error) {
+	authCtx, ok := auth.FromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "missing auth context")
+	}
+
 	normalizedPath, err := authz.NormalizePath(req.Path)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid path")
 	}
-	if err := h.objects.Upload(ctx, normalizedPath, req.Content); err != nil {
+	if err := h.ensureTenantAccess(ctx, authCtx, normalizedPath, auth.PermWrite); err != nil {
 		return nil, err
 	}
+	h.auditor.EmitTaskEvent(ctx, "upload.started", "", correlationIDFromContext(ctx), normalizedPath)
+	if h.uploads == nil {
+		if err := h.objects.Upload(ctx, normalizedPath, req.Content); err != nil {
+			return nil, err
+		}
+	} else {
+		idempotencyKey := ""
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("x-idempotency-key"); len(vals) > 0 {
+				idempotencyKey = vals[0]
+			}
+		}
+		if _, err := h.uploads.UploadStream(ctx, normalizedPath, bytes.NewReader(req.Content), idempotencyKey); err != nil {
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+	}
+	h.auditor.EmitTaskEvent(ctx, "upload.completed", "", correlationIDFromContext(ctx), normalizedPath)
 	return &pb.UploadObjectResponse{Success: true}, nil
 }
 
@@ -234,20 +278,28 @@ func (h *GRPCHandler) DownloadObject(req *pb.DownloadObjectRequest, stream pb.Fi
 	defer r.Close()
 
 	buf := make([]byte, 64*1024)
+	hashr := sha256.New()
 	for {
 		n, err := r.Read(buf)
 		if n > 0 {
+			_, _ = hashr.Write(buf[:n])
 			if err2 := stream.Send(&pb.DownloadChunk{Data: buf[:n]}); err2 != nil {
 				return err2
 			}
 		}
 		if err == io.EOF {
-			return nil
+			break
 		}
 		if err != nil {
 			return err
 		}
 	}
+	if h.uploads != nil {
+		if err := h.uploads.VerifyIntegrityHash(objectPath, hex.EncodeToString(hashr.Sum(nil))); err != nil {
+			return status.Error(codes.DataLoss, "integrity validation failed")
+		}
+	}
+	return nil
 }
 
 func (h *GRPCHandler) ensureTenantAccess(ctx context.Context, authCtx auth.AuthContext, p string, perm auth.Permission) error {
@@ -257,14 +309,22 @@ func (h *GRPCHandler) ensureTenantAccess(ctx context.Context, authCtx auth.AuthC
 	}
 	allowed, err := h.tenantResolver.UserHasTenant(ctx, authCtx.UserID, tenantID)
 	if err != nil {
+		h.auditor.EmitTaskEvent(ctx, "auth.decision.error", "", correlationIDFromContext(ctx), "tenant resolution failed")
+		observability.DefaultMetrics.ObserveAuthzDecision(false, "tenant_resolver_error")
 		return status.Error(codes.Internal, "tenant resolution failed")
 	}
 	if !allowed {
+		h.auditor.EmitTaskEvent(ctx, "auth.decision.denied", "", correlationIDFromContext(ctx), "tenant access denied")
+		observability.DefaultMetrics.ObserveAuthzDecision(false, "tenant_membership")
 		return status.Error(codes.PermissionDenied, "tenant access denied")
 	}
 	if !auth.CanAccess(authCtx, p, perm, h.acl) {
+		h.auditor.EmitTaskEvent(ctx, "auth.decision.denied", "", correlationIDFromContext(ctx), "access denied")
+		observability.DefaultMetrics.ObserveAuthzDecision(false, "acl")
 		return status.Error(codes.PermissionDenied, "access denied")
 	}
+	h.auditor.EmitTaskEvent(ctx, "auth.decision.allowed", "", correlationIDFromContext(ctx), "access allowed")
+	observability.DefaultMetrics.ObserveAuthzDecision(true, "ok")
 	return nil
 }
 

--- a/file-engine/internal/handlers/grpc_handler_test.go
+++ b/file-engine/internal/handlers/grpc_handler_test.go
@@ -59,7 +59,7 @@ func tenantResolverForTests() auth.TenantResolver {
 }
 
 func TestCreateFolderRequiresAuthContext(t *testing.T) {
-	h := NewGRPCHandler(&fakeTaskQueue{}, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	_, err := h.CreateFolder(context.Background(), &pb.CreateFolderRequest{ParentPath: "/tenants/acme", FolderName: "reports"})
 	if status.Code(err) != codes.Unauthenticated {
@@ -68,7 +68,7 @@ func TestCreateFolderRequiresAuthContext(t *testing.T) {
 }
 
 func TestCreateFolderRejectsNonTenantPath(t *testing.T) {
-	h := NewGRPCHandler(&fakeTaskQueue{}, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
 
 	_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/projects/shared", FolderName: "reports"})
@@ -78,7 +78,7 @@ func TestCreateFolderRejectsNonTenantPath(t *testing.T) {
 }
 
 func TestCreateFolderRejectsUnauthorizedTenant(t *testing.T) {
-	h := NewGRPCHandler(&fakeTaskQueue{}, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
 
 	_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/beta", FolderName: "reports"})
@@ -89,7 +89,7 @@ func TestCreateFolderRejectsUnauthorizedTenant(t *testing.T) {
 
 func TestCreateFolderEnqueuesWithCorrelationAndActorFallback(t *testing.T) {
 	q := &fakeTaskQueue{}
-	h := NewGRPCHandler(q, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(q, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
 	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("x-request-id", "req-123"))
@@ -114,7 +114,7 @@ func TestCreateFolderEnqueuesWithCorrelationAndActorFallback(t *testing.T) {
 
 func TestGetTaskStatusRequiresAuthAndReturnsPersistedStatus(t *testing.T) {
 	q := &fakeTaskQueue{statuses: map[string]*redisq.TaskStatus{"task-abc": {TaskID: "task-abc", Status: "success", Message: "done"}}}
-	h := NewGRPCHandler(q, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(q, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	_, err := h.GetTaskStatus(context.Background(), &pb.TaskStatusRequest{TaskId: "task-abc"})
 	if status.Code(err) != codes.Unauthenticated {
@@ -133,7 +133,7 @@ func TestGetTaskStatusRequiresAuthAndReturnsPersistedStatus(t *testing.T) {
 
 func TestCreateFolderEnqueuesNormalizedPath(t *testing.T) {
 	q := &fakeTaskQueue{}
-	h := NewGRPCHandler(q, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(q, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
 	_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: `tenants\acme\projects//`, FolderName: "reports"})
@@ -152,7 +152,7 @@ func TestCreateFolderEnqueuesNormalizedPath(t *testing.T) {
 }
 
 func TestCreateFolderWithNilResolverDefaultsToDenyAll(t *testing.T) {
-	h := NewGRPCHandler(&fakeTaskQueue{}, nil, auth.NewInMemoryACLStore(), nil, nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, nil, nil, auth.NewInMemoryACLStore(), nil, nil, nil)
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
 
 	_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/acme", FolderName: "reports"})
@@ -165,7 +165,7 @@ func TestListObjectsReturnsEntries(t *testing.T) {
 	root := t.TempDir()
 	st := localstorage.New(root)
 	obj := services.NewObjectService(st)
-	h := NewGRPCHandler(&fakeTaskQueue{}, obj, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	start := time.Now().Add(-time.Second)
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"viewer"}})
@@ -219,7 +219,7 @@ func TestListObjectsRequiresAuthContext(t *testing.T) {
 	root := t.TempDir()
 	st := localstorage.New(root)
 	obj := services.NewObjectService(st)
-	h := NewGRPCHandler(&fakeTaskQueue{}, obj, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	_, err := h.ListObjects(context.Background(), &pb.ListObjectsRequest{Prefix: "/tenants/acme/projects"})
 	if status.Code(err) != codes.Unauthenticated {
@@ -231,7 +231,7 @@ func TestListObjectsRejectsUnauthorizedTenant(t *testing.T) {
 	root := t.TempDir()
 	st := localstorage.New(root)
 	obj := services.NewObjectService(st)
-	h := NewGRPCHandler(&fakeTaskQueue{}, obj, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"viewer"}})
 	_, err := h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/beta/projects"})
@@ -254,12 +254,109 @@ func TestDownloadObjectRejectsUnauthorizedTenant(t *testing.T) {
 	root := t.TempDir()
 	st := localstorage.New(root)
 	obj := services.NewObjectService(st)
-	h := NewGRPCHandler(&fakeTaskQueue{}, obj, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
 
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"viewer"}})
 	stream := &fakeDownloadStream{ctx: ctx}
 	err := h.DownloadObject(&pb.DownloadObjectRequest{Path: "/tenants/beta/projects/report.txt"}, stream)
 	if status.Code(err) != codes.PermissionDenied {
 		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
+func TestUploadObjectRequiresAuthContext(t *testing.T) {
+	root := t.TempDir()
+	st := localstorage.New(root)
+	obj := services.NewObjectService(st)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
+
+	_, err := h.UploadObject(context.Background(), &pb.UploadObjectRequest{Path: "/tenants/acme/projects/new.txt", Content: []byte("ok")})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated, got %v", err)
+	}
+}
+
+func TestUploadObjectRejectsUnauthorizedTenant(t *testing.T) {
+	root := t.TempDir()
+	st := localstorage.New(root)
+	obj := services.NewObjectService(st)
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, nil)
+
+	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
+	_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/beta/projects/new.txt", Content: []byte("ok")})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}
+
+type auditSpyEvent struct {
+	event         string
+	taskID        string
+	correlationID string
+	message       string
+}
+
+type auditSpy struct {
+	events []auditSpyEvent
+}
+
+func (a *auditSpy) EmitTaskEvent(_ context.Context, event, taskID, correlationID, message string) {
+	a.events = append(a.events, auditSpyEvent{event: event, taskID: taskID, correlationID: correlationID, message: message})
+}
+
+func TestCreateFolderEmitsAuditForAuthDecisionAndEnqueue(t *testing.T) {
+	q := &fakeTaskQueue{}
+	auditor := &auditSpy{}
+	h := NewGRPCHandler(q, nil, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, auditor)
+
+	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("x-request-id", "req-audit-1"))
+
+	_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/acme", FolderName: "reports"})
+	if err != nil {
+		t.Fatalf("CreateFolder returned error: %v", err)
+	}
+
+	if len(auditor.events) < 3 {
+		t.Fatalf("expected at least 3 audit events, got %+v", auditor.events)
+	}
+	if auditor.events[0].event != "auth.decision.allowed" {
+		t.Fatalf("expected first event auth.decision.allowed, got %+v", auditor.events[0])
+	}
+	if auditor.events[1].event != "task.enqueued" {
+		t.Fatalf("expected second event task.enqueued, got %+v", auditor.events[1])
+	}
+	if auditor.events[2].event != "folder.mutation.requested" {
+		t.Fatalf("expected third event folder.mutation.requested, got %+v", auditor.events[2])
+	}
+}
+
+func TestUploadObjectEmitsAuditStartAndFinish(t *testing.T) {
+	root := t.TempDir()
+	st := localstorage.New(root)
+	obj := services.NewObjectService(st)
+	auditor := &auditSpy{}
+	h := NewGRPCHandler(&fakeTaskQueue{}, obj, nil, auth.NewInMemoryACLStore(), tenantResolverForTests(), nil, auditor)
+
+	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("x-request-id", "req-upload-audit"))
+
+	_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/acme/projects/a.txt", Content: []byte("ok")})
+	if err != nil {
+		t.Fatalf("UploadObject returned error: %v", err)
+	}
+
+	seenStart := false
+	seenFinish := false
+	for _, ev := range auditor.events {
+		if ev.event == "upload.started" {
+			seenStart = true
+		}
+		if ev.event == "upload.completed" {
+			seenFinish = true
+		}
+	}
+	if !seenStart || !seenFinish {
+		t.Fatalf("expected upload.started and upload.completed events, got %+v", auditor.events)
 	}
 }

--- a/file-engine/internal/observability/metrics.go
+++ b/file-engine/internal/observability/metrics.go
@@ -2,10 +2,55 @@ package observability
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 )
+
+type counterVec struct {
+	values sync.Map
+}
+
+func (v *counterVec) inc(key string) {
+	val, _ := v.values.LoadOrStore(key, &atomic.Int64{})
+	val.(*atomic.Int64).Add(1)
+}
+
+func (v *counterVec) snapshot() map[string]int64 {
+	out := map[string]int64{}
+	v.values.Range(func(k, val any) bool {
+		key, _ := k.(string)
+		ctr, _ := val.(*atomic.Int64)
+		out[key] = ctr.Load()
+		return true
+	})
+	return out
+}
+
+type durationSummary struct {
+	count atomic.Int64
+	sumMs atomic.Int64
+	maxMs atomic.Int64
+}
+
+func (s *durationSummary) observe(ms int64) {
+	s.count.Add(1)
+	s.sumMs.Add(ms)
+	for {
+		cur := s.maxMs.Load()
+		if ms <= cur {
+			return
+		}
+		if s.maxMs.CompareAndSwap(cur, ms) {
+			return
+		}
+	}
+}
+
+func (s *durationSummary) snapshot() (count, sumMs, maxMs int64) {
+	return s.count.Load(), s.sumMs.Load(), s.maxMs.Load()
+}
 
 type Metrics struct {
 	queueDepth          atomic.Int64
@@ -13,23 +58,27 @@ type Metrics struct {
 	tasksRunningTotal   atomic.Int64
 	tasksSucceededTotal atomic.Int64
 	tasksFailedTotal    atomic.Int64
+	auditEventsTotal    atomic.Int64
+	auditSinkFailures   atomic.Int64
+	auditDeadLetters    atomic.Int64
+	queueLagMs          durationSummary
+	auditSinkLagMs      atomic.Int64
+	uploadDurationMs    durationSummary
 
 	statusTransitions sync.Map
+	httpRequests      counterVec
+	grpcRequests      counterVec
+	authzDecisions    counterVec
+	httpDurations     sync.Map
+	grpcDurations     sync.Map
 }
 
-func NewMetrics() *Metrics {
-	return &Metrics{}
-}
+func NewMetrics() *Metrics { return &Metrics{} }
 
 var DefaultMetrics = NewMetrics()
 
-func (m *Metrics) SetQueueDepth(depth int64) {
-	m.queueDepth.Store(depth)
-}
-
-func (m *Metrics) IncEnqueued() {
-	m.tasksEnqueuedTotal.Add(1)
-}
+func (m *Metrics) SetQueueDepth(depth int64) { m.queueDepth.Store(depth) }
+func (m *Metrics) IncEnqueued()              { m.tasksEnqueuedTotal.Add(1) }
 
 func (m *Metrics) ObserveStatus(status string) {
 	n := strings.ToLower(status)
@@ -46,8 +95,61 @@ func (m *Metrics) ObserveStatus(status string) {
 	}
 }
 
-func (m *Metrics) FailedTasksTotal() int64 {
-	return m.tasksFailedTotal.Load()
+func (m *Metrics) FailedTasksTotal() int64 { return m.tasksFailedTotal.Load() }
+func (m *Metrics) IncAuditEventEmitted()   { m.auditEventsTotal.Add(1) }
+func (m *Metrics) IncAuditSinkFailure()    { m.auditSinkFailures.Add(1) }
+func (m *Metrics) IncAuditDeadLetter()     { m.auditDeadLetters.Add(1) }
+
+func (m *Metrics) ObserveHTTPRequest(method, route string, status int, durationMs int64) {
+	method = strings.ToUpper(strings.TrimSpace(method))
+	if method == "" {
+		method = "UNKNOWN"
+	}
+	route = sanitizeLabel(route)
+	key := fmt.Sprintf("%s|%s|%d", method, route, status)
+	m.httpRequests.inc(key)
+	durKey := fmt.Sprintf("%s|%s", method, route)
+	val, _ := m.httpDurations.LoadOrStore(durKey, &durationSummary{})
+	val.(*durationSummary).observe(durationMs)
+}
+
+func (m *Metrics) ObserveGRPCRequest(method, code string, durationMs int64) {
+	method = sanitizeLabel(method)
+	code = sanitizeLabel(strings.ToLower(code))
+	key := fmt.Sprintf("%s|%s", method, code)
+	m.grpcRequests.inc(key)
+	val, _ := m.grpcDurations.LoadOrStore(method, &durationSummary{})
+	val.(*durationSummary).observe(durationMs)
+}
+
+func (m *Metrics) ObserveAuthzDecision(allowed bool, reason string) {
+	decision := "deny"
+	if allowed {
+		decision = "allow"
+	}
+	reason = sanitizeLabel(strings.ToLower(reason))
+	m.authzDecisions.inc(fmt.Sprintf("%s|%s", decision, reason))
+}
+
+func (m *Metrics) ObserveQueueLagMs(lagMs int64) {
+	if lagMs < 0 {
+		lagMs = 0
+	}
+	m.queueLagMs.observe(lagMs)
+}
+
+func (m *Metrics) SetAuditSinkLagMs(lagMs int64) {
+	if lagMs < 0 {
+		lagMs = 0
+	}
+	m.auditSinkLagMs.Store(lagMs)
+}
+
+func (m *Metrics) ObserveUploadDurationMs(d int64) {
+	if d < 0 {
+		d = 0
+	}
+	m.uploadDurationMs.observe(d)
 }
 
 func (m *Metrics) SnapshotPrometheus() string {
@@ -55,22 +157,27 @@ func (m *Metrics) SnapshotPrometheus() string {
 	fmt.Fprintf(&b, "# HELP fileengine_queue_depth Current queue depth\n")
 	fmt.Fprintf(&b, "# TYPE fileengine_queue_depth gauge\n")
 	fmt.Fprintf(&b, "fileengine_queue_depth %d\n", m.queueDepth.Load())
-
 	fmt.Fprintf(&b, "# HELP fileengine_tasks_enqueued_total Total enqueued tasks\n")
 	fmt.Fprintf(&b, "# TYPE fileengine_tasks_enqueued_total counter\n")
 	fmt.Fprintf(&b, "fileengine_tasks_enqueued_total %d\n", m.tasksEnqueuedTotal.Load())
-
 	fmt.Fprintf(&b, "# HELP fileengine_tasks_running_total Total running state transitions\n")
 	fmt.Fprintf(&b, "# TYPE fileengine_tasks_running_total counter\n")
 	fmt.Fprintf(&b, "fileengine_tasks_running_total %d\n", m.tasksRunningTotal.Load())
-
 	fmt.Fprintf(&b, "# HELP fileengine_tasks_succeeded_total Total successful tasks\n")
 	fmt.Fprintf(&b, "# TYPE fileengine_tasks_succeeded_total counter\n")
 	fmt.Fprintf(&b, "fileengine_tasks_succeeded_total %d\n", m.tasksSucceededTotal.Load())
-
 	fmt.Fprintf(&b, "# HELP fileengine_tasks_failed_total Total failed tasks\n")
 	fmt.Fprintf(&b, "# TYPE fileengine_tasks_failed_total counter\n")
 	fmt.Fprintf(&b, "fileengine_tasks_failed_total %d\n", m.tasksFailedTotal.Load())
+	fmt.Fprintf(&b, "# HELP fileengine_audit_events_total Total emitted audit events\n")
+	fmt.Fprintf(&b, "# TYPE fileengine_audit_events_total counter\n")
+	fmt.Fprintf(&b, "fileengine_audit_events_total %d\n", m.auditEventsTotal.Load())
+	fmt.Fprintf(&b, "# HELP fileengine_audit_sink_failures_total Total immutable sink export failures\n")
+	fmt.Fprintf(&b, "# TYPE fileengine_audit_sink_failures_total counter\n")
+	fmt.Fprintf(&b, "fileengine_audit_sink_failures_total %d\n", m.auditSinkFailures.Load())
+	fmt.Fprintf(&b, "# HELP fileengine_audit_dead_letters_total Total dead-lettered audit events\n")
+	fmt.Fprintf(&b, "# TYPE fileengine_audit_dead_letters_total counter\n")
+	fmt.Fprintf(&b, "fileengine_audit_dead_letters_total %d\n", m.auditDeadLetters.Load())
 
 	m.statusTransitions.Range(func(key, value any) bool {
 		name, _ := key.(string)
@@ -79,5 +186,83 @@ func (m *Metrics) SnapshotPrometheus() string {
 		return true
 	})
 
+	count, sum, max := m.queueLagMs.snapshot()
+	fmt.Fprintf(&b, "fileengine_queue_lag_ms_count %d\n", count)
+	fmt.Fprintf(&b, "fileengine_queue_lag_ms_sum %d\n", sum)
+	fmt.Fprintf(&b, "fileengine_queue_lag_ms_max %d\n", max)
+	fmt.Fprintf(&b, "fileengine_audit_sink_lag_ms %d\n", m.auditSinkLagMs.Load())
+	uCount, uSum, uMax := m.uploadDurationMs.snapshot()
+	fmt.Fprintf(&b, "fileengine_upload_duration_ms_count %d\n", uCount)
+	fmt.Fprintf(&b, "fileengine_upload_duration_ms_sum %d\n", uSum)
+	fmt.Fprintf(&b, "fileengine_upload_duration_ms_max %d\n", uMax)
+
+	emitCounterVec(&b, "fileengine_http_requests_total", []string{"method", "route", "status"}, m.httpRequests.snapshot())
+	emitCounterVec(&b, "fileengine_grpc_requests_total", []string{"method", "code"}, m.grpcRequests.snapshot())
+	emitCounterVec(&b, "fileengine_authz_decisions_total", []string{"decision", "reason"}, m.authzDecisions.snapshot())
+	emitDurationSummaries(&b, "fileengine_http_request_duration_ms", []string{"method", "route"}, &m.httpDurations)
+	emitDurationSummaries(&b, "fileengine_grpc_request_duration_ms", []string{"method"}, &m.grpcDurations)
 	return b.String()
+}
+
+func emitCounterVec(b *strings.Builder, metric string, labels []string, values map[string]int64) {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		parts := strings.Split(key, "|")
+		if len(parts) != len(labels) {
+			continue
+		}
+		fmt.Fprintf(b, "%s{", metric)
+		for i, label := range labels {
+			if i > 0 {
+				fmt.Fprintf(b, ",")
+			}
+			fmt.Fprintf(b, "%s=\"%s\"", label, sanitizeLabel(parts[i]))
+		}
+		fmt.Fprintf(b, "} %d\n", values[key])
+	}
+}
+
+func emitDurationSummaries(b *strings.Builder, metric string, labels []string, mp *sync.Map) {
+	pairs := map[string][3]int64{}
+	mp.Range(func(k, v any) bool {
+		key, _ := k.(string)
+		s, _ := v.(*durationSummary)
+		count, sum, max := s.snapshot()
+		pairs[key] = [3]int64{count, sum, max}
+		return true
+	})
+	keys := make([]string, 0, len(pairs))
+	for k := range pairs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		parts := strings.Split(key, "|")
+		if len(parts) != len(labels) {
+			continue
+		}
+		labelSet := ""
+		for i, label := range labels {
+			if i > 0 {
+				labelSet += ","
+			}
+			labelSet += fmt.Sprintf("%s=\"%s\"", label, sanitizeLabel(parts[i]))
+		}
+		v := pairs[key]
+		fmt.Fprintf(b, "%s_count{%s} %d\n", metric, labelSet, v[0])
+		fmt.Fprintf(b, "%s_sum{%s} %d\n", metric, labelSet, v[1])
+		fmt.Fprintf(b, "%s_max{%s} %d\n", metric, labelSet, v[2])
+	}
+}
+
+func sanitizeLabel(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "unknown"
+	}
+	return strings.ReplaceAll(v, "\"", "")
 }

--- a/file-engine/internal/observability/metrics_test.go
+++ b/file-engine/internal/observability/metrics_test.go
@@ -5,13 +5,23 @@ import (
 	"testing"
 )
 
-func TestSnapshotPrometheusIncludesQueueAndTaskCounters(t *testing.T) {
+func TestSnapshotPrometheusIncludesQueueTaskAndOperabilityMetrics(t *testing.T) {
 	m := NewMetrics()
 	m.SetQueueDepth(9)
 	m.IncEnqueued()
 	m.ObserveStatus("running")
 	m.ObserveStatus("success")
 	m.ObserveStatus("failed")
+	m.IncAuditEventEmitted()
+	m.IncAuditSinkFailure()
+	m.IncAuditDeadLetter()
+	m.ObserveAuthzDecision(true, "ok")
+	m.ObserveAuthzDecision(false, "tenant_membership")
+	m.ObserveHTTPRequest("post", "/v1/objects:upload", 201, 42)
+	m.ObserveGRPCRequest("/fileengine.FileEngine/ListObjects", "permission_denied", 7)
+	m.ObserveQueueLagMs(55)
+	m.SetAuditSinkLagMs(3)
+	m.ObserveUploadDurationMs(77)
 
 	snapshot := m.SnapshotPrometheus()
 	assertContains := func(expected string) {
@@ -27,4 +37,14 @@ func TestSnapshotPrometheusIncludesQueueAndTaskCounters(t *testing.T) {
 	assertContains("fileengine_tasks_succeeded_total 1")
 	assertContains("fileengine_tasks_failed_total 1")
 	assertContains("fileengine_task_status_transitions_total{status=\"failed\"} 1")
+	assertContains("fileengine_audit_events_total 1")
+	assertContains("fileengine_audit_sink_failures_total 1")
+	assertContains("fileengine_audit_dead_letters_total 1")
+	assertContains("fileengine_authz_decisions_total{decision=\"allow\",reason=\"ok\"} 1")
+	assertContains("fileengine_authz_decisions_total{decision=\"deny\",reason=\"tenant_membership\"} 1")
+	assertContains("fileengine_http_requests_total{method=\"POST\",route=\"/v1/objects:upload\",status=\"201\"} 1")
+	assertContains("fileengine_grpc_requests_total{method=\"/fileengine.FileEngine/ListObjects\",code=\"permission_denied\"} 1")
+	assertContains("fileengine_queue_lag_ms_sum 55")
+	assertContains("fileengine_audit_sink_lag_ms 3")
+	assertContains("fileengine_upload_duration_ms_max 77")
 }

--- a/file-engine/internal/security/validator.go
+++ b/file-engine/internal/security/validator.go
@@ -1,1 +1,31 @@
 package security
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func NormalizeTenantPath(raw string) (string, error) {
+	p := strings.TrimSpace(strings.ReplaceAll(raw, "\\", "/"))
+	if p == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("path traversal denied")
+		}
+	}
+	clean := path.Clean(p)
+	if !strings.HasPrefix(clean, "/tenants/") {
+		return "", fmt.Errorf("path must be tenant scoped")
+	}
+	parts := strings.Split(strings.TrimPrefix(clean, "/"), "/")
+	if len(parts) < 3 || parts[1] == "" {
+		return "", fmt.Errorf("invalid tenant path")
+	}
+	return clean, nil
+}

--- a/file-engine/internal/security/validator_test.go
+++ b/file-engine/internal/security/validator_test.go
@@ -1,0 +1,33 @@
+package security
+
+import "testing"
+
+func TestNormalizeTenantPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "normalizes separators", in: `tenants\acme\docs\a.txt`, want: "/tenants/acme/docs/a.txt"},
+		{name: "rejects traversal", in: "/tenants/acme/../etc/passwd", wantErr: true},
+		{name: "rejects non-tenant prefix", in: "/projects/a", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeTenantPath(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got path %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("want %q got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/file-engine/internal/server/readiness_test.go
+++ b/file-engine/internal/server/readiness_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleReadyzReturnsReadyWhenChecksPass(t *testing.T) {
+	h := &HTTPServer{}
+	h.AddReadyCheck("storage", func(context.Context) error { return nil })
+	h.AddReadyCheck("queue", func(context.Context) error { return nil })
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	h.handleReadyz(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestHandleReadyzReturnsServiceUnavailableWhenAnyCheckFails(t *testing.T) {
+	h := &HTTPServer{}
+	h.AddReadyCheck("storage", func(context.Context) error { return nil })
+	h.AddReadyCheck("queue", func(context.Context) error { return errors.New("redis unavailable") })
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	h.handleReadyz(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/file-engine/internal/server/server.go
+++ b/file-engine/internal/server/server.go
@@ -2,20 +2,26 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/example/file-engine/internal/observability"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/example/file-engine/internal/auth"
 	"github.com/example/file-engine/internal/authz"
 	"github.com/example/file-engine/internal/logger"
+	"github.com/example/file-engine/internal/services"
 	"github.com/example/file-engine/internal/storage"
 	pb "github.com/example/file-engine/pkg/generated"
 )
@@ -30,6 +36,11 @@ type GRPCServer struct {
 	Handler pb.FileEngineServer
 }
 
+type readinessCheck struct {
+	name string
+	fn   func(context.Context) error
+}
+
 type HTTPServer struct {
 	Addr     string
 	GRPCAddr string
@@ -39,18 +50,35 @@ type HTTPServer struct {
 	Storage  storage.Storage
 
 	ACLStore auth.ACLStore
+	Uploads  *services.UploadService
+
+	ReadyChecks []readinessCheck
+
+	MaxUploadBytes int64
+	UploadTimeout  time.Duration
+	sem            chan struct{}
+	rateMu         sync.Mutex
+	rateByTenant   map[string]int
+	rateReset      time.Time
 }
 
 func NewGRPCServer(addr string, logg *logger.Logger, verifier *auth.JWTVerifier, store auth.ACLStore, handler pb.FileEngineServer) *GRPCServer {
-	return &GRPCServer{
-		Addr: addr, Log: logg,
-		Verifier: verifier, ACLStore: store,
-		Handler: handler,
+	return &GRPCServer{Addr: addr, Log: logg, Verifier: verifier, ACLStore: store, Handler: handler}
+}
+
+func NewHTTPServer(addr, grpcAddr string, logg *logger.Logger, verifier *auth.JWTVerifier, st storage.Storage, store auth.ACLStore, uploads *services.UploadService) *HTTPServer {
+	return &HTTPServer{
+		Addr: addr, GRPCAddr: grpcAddr, Log: logg, Verifier: verifier, Storage: st, ACLStore: store, Uploads: uploads,
+		MaxUploadBytes: 20 * 1024 * 1024, UploadTimeout: 30 * time.Second,
+		sem: make(chan struct{}, 8), rateByTenant: map[string]int{}, rateReset: time.Now().Add(time.Minute),
 	}
 }
 
-func NewHTTPServer(addr, grpcAddr string, logg *logger.Logger, verifier *auth.JWTVerifier, st storage.Storage, store auth.ACLStore) *HTTPServer {
-	return &HTTPServer{Addr: addr, GRPCAddr: grpcAddr, Log: logg, Verifier: verifier, Storage: st, ACLStore: store}
+func (h *HTTPServer) AddReadyCheck(name string, check func(context.Context) error) {
+	if check == nil {
+		return
+	}
+	h.ReadyChecks = append(h.ReadyChecks, readinessCheck{name: name, fn: check})
 }
 
 func (g *GRPCServer) Start() error {
@@ -59,40 +87,53 @@ func (g *GRPCServer) Start() error {
 		return fmt.Errorf("listen: %w", err)
 	}
 
+	metricsUnary := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		grpcCode := codes.OK.String()
+		if err != nil {
+			grpcCode = status.Code(err).String()
+		}
+		observability.DefaultMetrics.ObserveGRPCRequest(info.FullMethod, grpcCode, time.Since(start).Milliseconds())
+		return resp, err
+	}
+	metricsStream := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		start := time.Now()
+		err := handler(srv, ss)
+		grpcCode := codes.OK.String()
+		if err != nil {
+			grpcCode = status.Code(err).String()
+		}
+		observability.DefaultMetrics.ObserveGRPCRequest(info.FullMethod, grpcCode, time.Since(start).Milliseconds())
+		return err
+	}
+
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
+			metricsUnary,
 			auth.GRPCAuthInterceptor(g.Verifier),
 			authz.GRPCAuthZInterceptor(g.ACLStore),
 		),
-		// Stream interceptors are required for server-streaming RPCs like DownloadObject.
 		grpc.ChainStreamInterceptor(
+			metricsStream,
 			auth.GRPCStreamAuthInterceptor(g.Verifier),
 			authz.GRPCAuthZStreamInterceptor(g.ACLStore),
 		),
 	}
 	srv := grpc.NewServer(opts...)
-
 	pb.RegisterFileEngineServer(srv, g.Handler)
-
 	g.Log.Infof("gRPC listening on %s", g.Addr)
 	return srv.Serve(lis)
 }
 
 func (h *HTTPServer) Start() error {
 	ctx := context.Background()
-
 	mux := runtime.NewServeMux()
 
-	conn, err := grpc.DialContext(
-		ctx,
-		h.GRPCAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	conn, err := grpc.DialContext(ctx, h.GRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("dial grpc: %w", err)
 	}
-
-	// Register gateway handlers
 	if err := pb.RegisterFileEngineHandler(ctx, mux, conn); err != nil {
 		return fmt.Errorf("register gateway: %w", err)
 	}
@@ -102,18 +143,82 @@ func (h *HTTPServer) Start() error {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
 		_, _ = w.Write([]byte(observability.DefaultMetrics.SnapshotPrometheus()))
 	})
-	// Raw download endpoint (REST-friendly): streams bytes directly.
+	root.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	root.HandleFunc("/readyz", h.handleReadyz)
 	root.HandleFunc("/v1/objects:download", h.handleDownload)
-
-	// Gateway endpoints (ListObjects, UploadObject, CreateFolder, TaskStatus, etc.)
+	root.HandleFunc("/v1/objects:upload", h.handleUpload)
 	root.Handle("/", auth.HTTPAuthMiddleware(h.Verifier, mux))
 
+	handler := h.instrumentHTTP(root)
 	srv := &http.Server{
 		Addr:              h.Addr,
-		Handler:           root,
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	if len(h.ReadyChecks) == 0 {
+		h.Log.Warnf("no readiness checks configured; /readyz will report ready")
 	}
 
 	h.Log.Infof("HTTP listening on %s (proxying to %s)", h.Addr, h.GRPCAddr)
 	return srv.ListenAndServe()
+}
+
+func (h *HTTPServer) instrumentHTTP(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := strings.TrimSpace(r.Header.Get("X-Request-Id"))
+		if requestID == "" {
+			requestID = fmt.Sprintf("req-%d", time.Now().UTC().UnixNano())
+		}
+		ww := &statusWriter{ResponseWriter: w, code: http.StatusOK}
+		ww.Header().Set("X-Request-Id", requestID)
+		start := time.Now()
+		next.ServeHTTP(ww, r)
+		route := r.URL.Path
+		if route == "" {
+			route = "/"
+		}
+		observability.DefaultMetrics.ObserveHTTPRequest(r.Method, route, ww.code, time.Since(start).Milliseconds())
+	})
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	code int
+}
+
+func (w *statusWriter) WriteHeader(statusCode int) {
+	w.code = statusCode
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (h *HTTPServer) handleReadyz(w http.ResponseWriter, r *http.Request) {
+	if len(h.ReadyChecks) == 0 {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ready"))
+		return
+	}
+	failed := map[string]string{}
+	for _, c := range h.ReadyChecks {
+		cctx, cancel := context.WithTimeout(r.Context(), 1500*time.Millisecond)
+		err := c.fn(cctx)
+		cancel()
+		if err != nil {
+			failed[c.name] = err.Error()
+		}
+	}
+	if len(failed) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ready": false, "failed": failed})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{"ready": true})
 }

--- a/file-engine/internal/server/upload_http.go
+++ b/file-engine/internal/server/upload_http.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/example/file-engine/internal/observability"
+
+	"github.com/example/file-engine/internal/auth"
+	"github.com/example/file-engine/internal/security"
+)
+
+func (h *HTTPServer) handleUpload(w http.ResponseWriter, r *http.Request) {
+	if h.Uploads == nil {
+		http.Error(w, "upload pipeline unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	start := time.Now()
+	a, err := h.Verifier.ParseAuthContext(r.Header.Get("Authorization"))
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	rawPath := r.URL.Query().Get("path")
+	normalizedPath, err := security.NormalizeTenantPath(rawPath)
+	if err != nil {
+		http.Error(w, "invalid path", http.StatusBadRequest)
+		return
+	}
+	if !auth.CanAccess(a, normalizedPath, auth.PermWrite, h.ACLStore) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if !h.allowTenantRequest(tenantFromNormalizedPath(normalizedPath)) {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	select {
+	case h.sem <- struct{}{}:
+		defer func() { <-h.sem }()
+	default:
+		http.Error(w, "too many concurrent uploads", http.StatusTooManyRequests)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, h.MaxUploadBytes)
+	ctx := r.Context()
+	if h.UploadTimeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, h.UploadTimeout)
+		defer cancel()
+	}
+	idk := r.Header.Get("X-Idempotency-Key")
+	if _, err := h.Uploads.UploadStream(ctx, normalizedPath, r.Body, idk); err != nil {
+		http.Error(w, err.Error(), http.StatusFailedDependency)
+		return
+	}
+	observability.DefaultMetrics.ObserveUploadDurationMs(time.Since(start).Milliseconds())
+	w.WriteHeader(http.StatusCreated)
+}
+
+func tenantFromNormalizedPath(p string) string {
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+func (h *HTTPServer) allowTenantRequest(tenant string) bool {
+	h.rateMu.Lock()
+	defer h.rateMu.Unlock()
+	now := time.Now()
+	if now.After(h.rateReset) {
+		h.rateByTenant = map[string]int{}
+		h.rateReset = now.Add(time.Minute)
+	}
+	h.rateByTenant[tenant]++
+	return h.rateByTenant[tenant] <= 120
+}

--- a/file-engine/internal/server/upload_http_test.go
+++ b/file-engine/internal/server/upload_http_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	adaptersecurity "github.com/example/file-engine/internal/adapters/security"
+	localstorage "github.com/example/file-engine/internal/adapters/storage/local"
+	"github.com/example/file-engine/internal/auth"
+	"github.com/example/file-engine/internal/services"
+)
+
+func TestHandleUploadStreamsAndCreatesObject(t *testing.T) {
+	secret := "test-secret"
+	verifier, _ := auth.NewJWTVerifier(secret, "", "", "")
+	acl := auth.NewInMemoryACLStore()
+	_ = acl.SetACL(auth.ACL{Path: "/tenants/acme", PrincipalID: "role:viewer", Permissions: map[auth.Permission]bool{auth.PermWrite: true}})
+
+	st := localstorage.New(t.TempDir())
+	uploads := services.NewUploadService(st, adaptersecurity.NewMalwareScannerStub(), services.UploadPolicy{MaxObjectSizeBytes: 1024, TenantQuotaBytes: 10 * 1024, RequestTimeout: time.Second, RequireCleanScan: false})
+	h := &HTTPServer{Verifier: verifier, ACLStore: acl, Uploads: uploads, MaxUploadBytes: 1024, UploadTimeout: time.Second, sem: make(chan struct{}, 1), rateByTenant: map[string]int{}, rateReset: time.Now().Add(time.Minute)}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/objects:upload?path=/tenants/acme/docs/a.txt", bytes.NewBufferString("hello"))
+	req.Header.Set("Authorization", signedToken(t, secret))
+	rr := httptest.NewRecorder()
+	h.handleUpload(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", rr.Code)
+	}
+}
+
+func TestHandleUploadRejectsRateLimit(t *testing.T) {
+	secret := "test-secret"
+	verifier, _ := auth.NewJWTVerifier(secret, "", "", "")
+	acl := auth.NewInMemoryACLStore()
+	_ = acl.SetACL(auth.ACL{Path: "/tenants/acme", PrincipalID: "role:viewer", Permissions: map[auth.Permission]bool{auth.PermWrite: true}})
+	st := localstorage.New(t.TempDir())
+	uploads := services.NewUploadService(st, adaptersecurity.NewMalwareScannerStub(), services.UploadPolicy{MaxObjectSizeBytes: 1024, TenantQuotaBytes: 10 * 1024, RequestTimeout: time.Second, RequireCleanScan: false})
+	h := &HTTPServer{Verifier: verifier, ACLStore: acl, Uploads: uploads, MaxUploadBytes: 1024, UploadTimeout: time.Second, sem: make(chan struct{}, 1), rateByTenant: map[string]int{"acme": 120}, rateReset: time.Now().Add(time.Minute)}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/objects:upload?path=/tenants/acme/docs/a.txt", bytes.NewBufferString("hello"))
+	req.Header.Set("Authorization", signedToken(t, secret))
+	rr := httptest.NewRecorder()
+	h.handleUpload(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 got %d", rr.Code)
+	}
+}

--- a/file-engine/internal/services/object_service.go
+++ b/file-engine/internal/services/object_service.go
@@ -3,17 +3,22 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
+	"sync"
 
 	"github.com/example/file-engine/internal/storage"
 )
 
 type ObjectService struct {
-	st storage.Storage
+	st        storage.Storage
+	mu        sync.RWMutex
+	checksums map[string]string
 }
 
 func NewObjectService(st storage.Storage) *ObjectService {
-	return &ObjectService{st: st}
+	return &ObjectService{st: st, checksums: map[string]string{}}
 }
 
 func (s *ObjectService) List(ctx context.Context, prefix string) ([]storage.ObjectInfo, error) {
@@ -21,7 +26,21 @@ func (s *ObjectService) List(ctx context.Context, prefix string) ([]storage.Obje
 }
 
 func (s *ObjectService) Upload(ctx context.Context, path string, content []byte) error {
-	return s.st.AtomicWrite(ctx, path, bytes.NewReader(content))
+	if err := s.st.AtomicWrite(ctx, path, bytes.NewReader(content)); err != nil {
+		return err
+	}
+	sum := sha256.Sum256(content)
+	s.mu.Lock()
+	s.checksums[path] = hex.EncodeToString(sum[:])
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *ObjectService) Checksum(path string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.checksums[path]
+	return v, ok
 }
 
 func (s *ObjectService) Open(ctx context.Context, path string) (io.ReadCloser, error) {

--- a/file-engine/internal/services/upload_service.go
+++ b/file-engine/internal/services/upload_service.go
@@ -1,0 +1,198 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/example/file-engine/internal/app/ports"
+	"github.com/example/file-engine/internal/security"
+	"github.com/example/file-engine/internal/storage"
+)
+
+type UploadPolicy struct {
+	MaxObjectSizeBytes int64
+	TenantQuotaBytes   int64
+	TenantObjectLimit  int64
+	RequestTimeout     time.Duration
+	RequireCleanScan   bool
+}
+
+type UploadMetadata struct {
+	TenantID   string
+	Path       string
+	StagePath  string
+	Size       int64
+	Checksum   string
+	ScanStatus ports.MalwareScanStatus
+	ScannedBy  string
+	CreatedAt  time.Time
+}
+
+type UploadService struct {
+	st      storage.Storage
+	scanner ports.MalwareScanner
+	policy  UploadPolicy
+
+	mu          sync.RWMutex
+	metadata    map[string]UploadMetadata
+	idempotency map[string]UploadMetadata
+}
+
+func NewUploadService(st storage.Storage, scanner ports.MalwareScanner, policy UploadPolicy) *UploadService {
+	if policy.RequestTimeout <= 0 {
+		policy.RequestTimeout = 10 * time.Second
+	}
+	return &UploadService{st: st, scanner: scanner, policy: policy, metadata: map[string]UploadMetadata{}, idempotency: map[string]UploadMetadata{}}
+}
+
+func (s *UploadService) Upload(ctx context.Context, targetPath string, content []byte) (UploadMetadata, error) {
+	return s.UploadStream(ctx, targetPath, bytes.NewReader(content), "")
+}
+
+func (s *UploadService) UploadStream(ctx context.Context, targetPath string, content io.Reader, idempotencyKey string) (UploadMetadata, error) {
+	if idempotencyKey != "" {
+		s.mu.RLock()
+		if m, ok := s.idempotency[idempotencyKey]; ok {
+			s.mu.RUnlock()
+			return m, nil
+		}
+		s.mu.RUnlock()
+	}
+
+	normalized, err := security.NormalizeTenantPath(targetPath)
+	if err != nil {
+		return UploadMetadata{}, err
+	}
+	tenantID := tenantFromPath(normalized)
+	if tenantID == "" {
+		return UploadMetadata{}, fmt.Errorf("invalid tenant path")
+	}
+	if s.policy.TenantQuotaBytes > 0 {
+		used, objects := s.tenantUsage(tenantID)
+		if s.policy.TenantObjectLimit > 0 && objects >= s.policy.TenantObjectLimit {
+			return UploadMetadata{}, fmt.Errorf("tenant object count limit exceeded")
+		}
+		if used >= s.policy.TenantQuotaBytes {
+			return UploadMetadata{}, fmt.Errorf("tenant quota exceeded")
+		}
+	}
+
+	tctx, cancel := context.WithTimeout(ctx, s.policy.RequestTimeout)
+	defer cancel()
+
+	stagePath := path.Join("/quarantine", tenantID, fmt.Sprintf("upload-%d.bin", time.Now().UTC().UnixNano()))
+	h := sha256.New()
+	cr := &countingReader{r: content}
+	tr := io.TeeReader(cr, h)
+
+	if err := s.st.AtomicWrite(tctx, stagePath, tr); err != nil {
+		return UploadMetadata{}, err
+	}
+	if s.policy.MaxObjectSizeBytes > 0 && cr.n > s.policy.MaxObjectSizeBytes {
+		_ = s.st.Delete(tctx, stagePath)
+		return UploadMetadata{}, fmt.Errorf("max object size exceeded")
+	}
+	if s.policy.TenantQuotaBytes > 0 {
+		used, _ := s.tenantUsage(tenantID)
+		if used+cr.n > s.policy.TenantQuotaBytes {
+			_ = s.st.Delete(tctx, stagePath)
+			return UploadMetadata{}, fmt.Errorf("tenant quota exceeded")
+		}
+	}
+
+	checksum := hex.EncodeToString(h.Sum(nil))
+	scanStatus := ports.MalwareStatusUnknown
+	scannedBy := ""
+	if s.scanner != nil {
+		result, err := s.scanner.Scan(tctx, stagePath)
+		if err != nil {
+			scanStatus = ports.MalwareStatusUnknown
+		} else {
+			scanStatus = result.Status
+			scannedBy = result.Engine
+		}
+	}
+	if s.policy.RequireCleanScan && scanStatus != ports.MalwareStatusClean {
+		meta := UploadMetadata{TenantID: tenantID, Path: normalized, StagePath: stagePath, Size: cr.n, Checksum: checksum, ScanStatus: ports.MalwareStatusQuarantined, ScannedBy: scannedBy, CreatedAt: time.Now().UTC()}
+		s.storeMeta(meta, idempotencyKey)
+		return meta, fmt.Errorf("malware scan gate blocked commit")
+	}
+
+	if err := s.st.Move(tctx, stagePath, normalized); err != nil {
+		return UploadMetadata{}, err
+	}
+	meta := UploadMetadata{TenantID: tenantID, Path: normalized, StagePath: stagePath, Size: cr.n, Checksum: checksum, ScanStatus: scanStatus, ScannedBy: scannedBy, CreatedAt: time.Now().UTC()}
+	s.storeMeta(meta, idempotencyKey)
+	return meta, nil
+}
+
+func (s *UploadService) VerifyIntegrity(path string, content []byte) error {
+	sum := sha256.Sum256(content)
+	return s.VerifyIntegrityHash(path, hex.EncodeToString(sum[:]))
+}
+
+func (s *UploadService) VerifyIntegrityHash(path string, checksumHex string) error {
+	normalized, err := security.NormalizeTenantPath(path)
+	if err != nil {
+		return err
+	}
+	s.mu.RLock()
+	meta, ok := s.metadata[normalized]
+	s.mu.RUnlock()
+	if !ok || meta.Checksum == "" {
+		return nil
+	}
+	if checksumHex != meta.Checksum {
+		return fmt.Errorf("checksum mismatch")
+	}
+	return nil
+}
+
+func (s *UploadService) tenantUsage(tenantID string) (int64, int64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var total, count int64
+	for _, m := range s.metadata {
+		if m.TenantID == tenantID && m.ScanStatus != ports.MalwareStatusQuarantined {
+			total += m.Size
+			count++
+		}
+	}
+	return total, count
+}
+
+func (s *UploadService) storeMeta(m UploadMetadata, idempotencyKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metadata[m.Path] = m
+	if idempotencyKey != "" {
+		s.idempotency[idempotencyKey] = m
+	}
+}
+
+func tenantFromPath(p string) string {
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	if len(parts) < 2 || parts[0] != "tenants" {
+		return ""
+	}
+	return parts[1]
+}
+
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}

--- a/file-engine/internal/services/upload_service_test.go
+++ b/file-engine/internal/services/upload_service_test.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	localstorage "github.com/example/file-engine/internal/adapters/storage/local"
+	"github.com/example/file-engine/internal/app/ports"
+)
+
+type scannerStub struct{ result ports.MalwareScanResult }
+
+func (s scannerStub) Scan(context.Context, string) (ports.MalwareScanResult, error) {
+	return s.result, nil
+}
+
+type failMoveStorage struct{ *localstorage.LocalStorage }
+
+func (f failMoveStorage) Move(context.Context, string, string) error {
+	return errors.New("move failed")
+}
+
+func TestUploadServiceStagesScansAndCommits(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusClean, Engine: "stub"}}, UploadPolicy{MaxObjectSizeBytes: 10, TenantQuotaBytes: 100, RequestTimeout: time.Second, RequireCleanScan: true})
+
+	meta, err := svc.Upload(context.Background(), "/tenants/acme/docs/a.txt", []byte("ok"))
+	if err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+	if meta.Checksum == "" || meta.ScanStatus != ports.MalwareStatusClean {
+		t.Fatalf("unexpected metadata: %+v", meta)
+	}
+	r, err := st.Open(context.Background(), "/tenants/acme/docs/a.txt")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+	b, _ := io.ReadAll(r)
+	if string(b) != "ok" {
+		t.Fatalf("unexpected content %q", string(b))
+	}
+	if err := svc.VerifyIntegrity("/tenants/acme/docs/a.txt", b); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+}
+
+func TestUploadServiceBlocksWhenScanGateFails(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusInfected, Engine: "stub"}}, UploadPolicy{MaxObjectSizeBytes: 10, TenantQuotaBytes: 100, RequestTimeout: time.Second, RequireCleanScan: true})
+	_, err := svc.Upload(context.Background(), "/tenants/acme/docs/eicar.txt", []byte("eicar"))
+	if err == nil {
+		t.Fatalf("expected scan gate failure")
+	}
+}
+
+func TestUploadServiceQuotaLimit(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusClean}}, UploadPolicy{MaxObjectSizeBytes: 20, TenantQuotaBytes: 3, TenantObjectLimit: 10, RequestTimeout: time.Second})
+	if _, err := svc.Upload(context.Background(), "/tenants/acme/docs/a.txt", []byte("ab")); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if _, err := svc.Upload(context.Background(), "/tenants/acme/docs/b.txt", []byte("cd")); err == nil {
+		t.Fatalf("expected quota error")
+	}
+}
+
+func TestUploadServiceAtomicCommitOnMoveError(t *testing.T) {
+	base := localstorage.New(t.TempDir())
+	svc := NewUploadService(failMoveStorage{base}, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusClean}}, UploadPolicy{MaxObjectSizeBytes: 20, TenantQuotaBytes: 100, RequestTimeout: time.Second})
+	_, err := svc.Upload(context.Background(), "/tenants/acme/docs/a.txt", []byte("abc"))
+	if err == nil {
+		t.Fatalf("expected move failure")
+	}
+}
+
+func TestUploadServiceChecksumMismatch(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusClean}}, UploadPolicy{MaxObjectSizeBytes: 20, TenantQuotaBytes: 100, RequestTimeout: time.Second})
+	_, err := svc.Upload(context.Background(), "/tenants/acme/docs/a.txt", []byte("abc"))
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if err := svc.VerifyIntegrity("/tenants/acme/docs/a.txt", bytes.NewBufferString("zzz").Bytes()); err == nil {
+		t.Fatalf("expected checksum mismatch")
+	}
+}

--- a/file-engine/tests/integration/read_list_authz_integration_test.go
+++ b/file-engine/tests/integration/read_list_authz_integration_test.go
@@ -9,18 +9,44 @@ import (
 	"testing"
 	"time"
 
+	"github.com/example/file-engine/internal/adapters/queue/redisq"
 	localstorage "github.com/example/file-engine/internal/adapters/storage/local"
 	"github.com/example/file-engine/internal/auth"
 	"github.com/example/file-engine/internal/handlers"
 	"github.com/example/file-engine/internal/services"
 	pb "github.com/example/file-engine/pkg/generated"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
+type integrationQueueStub struct{}
+
+func (integrationQueueStub) EnqueueCreateFolder(_ context.Context, _, _, _, _ string) (string, error) {
+	return "task-integration", nil
+}
+
+func (integrationQueueStub) GetStatus(_ context.Context, _ string) (*redisq.TaskStatus, error) {
+	return nil, redisq.ErrTaskNotFound
+}
+
+type downloadCaptureStream struct {
+	grpc.ServerStream
+	ctx    context.Context
+	chunks [][]byte
+}
+
+func (s *downloadCaptureStream) Context() context.Context { return s.ctx }
+
+func (s *downloadCaptureStream) Send(chunk *pb.DownloadChunk) error {
+	s.chunks = append(s.chunks, append([]byte(nil), chunk.GetData()...))
+	return nil
+}
+
 func tenantResolverSeed() auth.TenantResolver {
 	return auth.NewInMemoryTenantResolver(map[string][]string{
-		"alice": []string{"acme"},
+		"alice": {"acme"},
 	})
 }
 
@@ -30,7 +56,7 @@ func TestReadListBehaviorAndAuthzRejection(t *testing.T) {
 	root := t.TempDir()
 	storage := localstorage.New(root)
 	objectService := services.NewObjectService(storage)
-	h := handlers.NewGRPCHandler(nil, objectService, auth.NewInMemoryACLStore(), tenantResolverSeed(), nil)
+	h := handlers.NewGRPCHandler(integrationQueueStub{}, objectService, nil, auth.NewInMemoryACLStore(), tenantResolverSeed(), nil, nil)
 
 	ctx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"viewer"}})
 
@@ -62,8 +88,201 @@ func TestReadListBehaviorAndAuthzRejection(t *testing.T) {
 		t.Fatalf("expected created_at after %v, got %+v", start, resp.Items[0].CreatedAt)
 	}
 
-	_, err = h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/beta/projects"})
-	if status.Code(err) != codes.PermissionDenied {
-		t.Fatalf("expected permission denied for unauthorized tenant list, got %v", err)
+	cases := []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{
+			name: "list unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/beta/projects"})
+				return err
+			},
+		},
+		{
+			name: "read/download unauthorized tenant",
+			run: func(ctx context.Context) error {
+				stream := &downloadCaptureStream{ctx: ctx}
+				return h.DownloadObject(&pb.DownloadObjectRequest{Path: "/tenants/beta/projects/readme.txt"}, stream)
+			},
+		},
+		{
+			name: "upload unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/beta/projects/upload.txt", Content: []byte("payload")})
+				return err
+			},
+		},
+		{
+			name: "create folder unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/beta/projects", FolderName: "reports"})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.run(ctx)
+			if status.Code(err) != codes.PermissionDenied {
+				t.Fatalf("expected permission denied, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCrossTenantPolicyCoverageWithTableDrivenCases(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	storage := localstorage.New(root)
+	objectService := services.NewObjectService(storage)
+	h := handlers.NewGRPCHandler(integrationQueueStub{}, objectService, nil, auth.NewInMemoryACLStore(), tenantResolverSeed(), nil, nil)
+
+	baseCtx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
+	ctx := metadata.NewIncomingContext(baseCtx, metadata.Pairs("x-request-id", "integration-tenant-deny"))
+
+	if err := storage.CreateFolder(ctx, "/tenants/acme/projects"); err != nil {
+		t.Fatalf("create authorized tenant folder: %v", err)
+	}
+	if err := storage.AtomicWrite(ctx, "/tenants/acme/projects/existing.txt", bytes.NewBufferString("ok")); err != nil {
+		t.Fatalf("write authorized tenant file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		run          func(context.Context) error
+		expectDenied bool
+	}{
+		{
+			name: "list authorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/acme/projects"})
+				return err
+			},
+			expectDenied: false,
+		},
+		{
+			name: "list unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/beta/projects"})
+				return err
+			},
+			expectDenied: true,
+		},
+		{
+			name: "upload authorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/acme/projects/new.txt", Content: []byte("ok")})
+				return err
+			},
+			expectDenied: false,
+		},
+		{
+			name: "upload unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/beta/projects/new.txt", Content: []byte("no")})
+				return err
+			},
+			expectDenied: true,
+		},
+		{
+			name: "create folder authorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/acme/projects", FolderName: "reports"})
+				return err
+			},
+			expectDenied: false,
+		},
+		{
+			name: "create folder unauthorized tenant",
+			run: func(ctx context.Context) error {
+				_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{ParentPath: "/tenants/beta/projects", FolderName: "reports"})
+				return err
+			},
+			expectDenied: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run(ctx)
+			if tc.expectDenied {
+				if status.Code(err) != codes.PermissionDenied {
+					t.Fatalf("expected permission denied, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected success, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEngineBoundaryDeniesCrossTenantEvenWithBuggyUpstreamInputs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	storage := localstorage.New(root)
+	objectService := services.NewObjectService(storage)
+	h := handlers.NewGRPCHandler(integrationQueueStub{}, objectService, nil, auth.NewInMemoryACLStore(), tenantResolverSeed(), nil, nil)
+
+	baseCtx := auth.WithAuthContext(context.Background(), auth.AuthContext{UserID: "alice", Roles: []string{"admin"}})
+	ctx := metadata.NewIncomingContext(baseCtx, metadata.Pairs("x-request-id", "integration-buggy-upstream"))
+
+	if err := storage.CreateFolder(ctx, "/tenants/acme/projects"); err != nil {
+		t.Fatalf("create authorized tenant folder: %v", err)
+	}
+	if err := storage.AtomicWrite(ctx, "/tenants/acme/projects/ok.txt", bytes.NewBufferString("ok")); err != nil {
+		t.Fatalf("write authorized tenant file: %v", err)
+	}
+
+	// requestedBy below intentionally simulates buggy upstream behavior: it claims a privileged
+	// identity different from the authenticated subject. The engine must still deny by auth context
+	// user-to-tenant mapping and final in-engine authz checks.
+	tests := []struct {
+		name string
+		run  func(context.Context) error
+	}{
+		{
+			name: "list denied on unauthorized tenant despite upstream context",
+			run: func(ctx context.Context) error {
+				_, err := h.ListObjects(ctx, &pb.ListObjectsRequest{Prefix: "/tenants/beta/projects"})
+				return err
+			},
+		},
+		{
+			name: "upload denied on unauthorized tenant despite upstream context",
+			run: func(ctx context.Context) error {
+				_, err := h.UploadObject(ctx, &pb.UploadObjectRequest{Path: "/tenants/beta/projects/pwned.txt", Content: []byte("no")})
+				return err
+			},
+		},
+		{
+			name: "folder op denied on unauthorized tenant despite spoofed requestedBy",
+			run: func(ctx context.Context) error {
+				_, err := h.CreateFolder(ctx, &pb.CreateFolderRequest{
+					ParentPath:  "/tenants/beta/projects",
+					FolderName:  "finance",
+					RequestedBy: "superadmin@upstream.local",
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run(ctx)
+			if status.Code(err) != codes.PermissionDenied {
+				t.Fatalf("expected permission denied, got %v", err)
+			}
+		})
 	}
 }

--- a/file-engine/tests/integration/worker_integration_test.go
+++ b/file-engine/tests/integration/worker_integration_test.go
@@ -166,14 +166,19 @@ func TestAsyncCreateFolderFlow(t *testing.T) {
 			}
 
 			auditEvents := auditor.Snapshot()
-			if len(auditEvents) != 2 {
-				t.Fatalf("expected exactly 2 audit events, got %d (%+v)", len(auditEvents), auditEvents)
+			expectedAudit := []auditEvent{
+				{event: "task.dequeued", taskID: taskID, correlationID: correlationID},
+				{event: "task.processing", taskID: taskID, correlationID: correlationID},
+				{event: "task.succeeded", taskID: taskID, correlationID: correlationID},
+				{event: "folder.mutation.succeeded", taskID: taskID, correlationID: correlationID},
 			}
-			if auditEvents[0] != (auditEvent{event: "task.processing", taskID: taskID, correlationID: correlationID}) {
-				t.Fatalf("expected first audit event to be task.processing for task %s, got %+v", taskID, auditEvents[0])
+			if len(auditEvents) != len(expectedAudit) {
+				t.Fatalf("expected %d audit events, got %d (%+v)", len(expectedAudit), len(auditEvents), auditEvents)
 			}
-			if auditEvents[1] != (auditEvent{event: "task.succeeded", taskID: taskID, correlationID: correlationID}) {
-				t.Fatalf("expected second audit event to be task.succeeded for task %s, got %+v", taskID, auditEvents[1])
+			for i := range expectedAudit {
+				if auditEvents[i] != expectedAudit[i] {
+					t.Fatalf("expected audit event[%d]=%+v, got %+v", i, expectedAudit[i], auditEvents[i])
+				}
 			}
 			return
 		}


### PR DESCRIPTION
### Motivation
- Provide production-style operability: explicit readiness semantics that validate storage/queue/DB dependencies rather than only process liveness.
- Improve observability so teams can build RED-style dashboards and diagnose authz/queue problems with labeled counters and duration summaries.
- Improve end-to-end traceability by propagating request/correlation identifiers through the HTTP → queue → worker path and tying audit emissions to those IDs.

### Description
- Add HTTP readiness endpoint `/readyz` with DI-wired checks for storage `List`, Redis `PING`, and Postgres `Ping` when configured, while keeping `/healthz` as liveness; wire checks from the DI container. (`file-engine/internal/server`, `file-engine/internal/di/container.go`).
- Implement richer operability metrics: labeled HTTP/gRPC request counters and duration summaries, authz allow/deny counters with reason codes, queue lag and upload-duration summaries, plus audit sink metrics and helpers to emit Prometheus-format text on `/metrics`. (`file-engine/internal/observability/metrics.go`, tests).
- Propagate request identifiers across layers and surface them in logs/audit events: set `X-Request-Id` on HTTP responses, include `request_id` in queued payloads, and fall back to `request_id` in worker logs/audit flows for end-to-end correlation. (server, redisq, worker, handlers changes).
- Add upload pipeline and safety primitives: streaming `UploadService` with staging/quarantine, incremental SHA-256 checksumming, tenant quota/object limits, malware scanner port + stub, idempotency handling, and integrity verification wired into gRPC download path; plus atomic FS helpers. (`file-engine/internal/services/upload_service.go`, `object_service.go`, adapters, ports, malware scanner stub).
- Add dual-layer audit emitters and immutable sink abstractions (file/bucket/Loki) with retry + dead-letter handling and metrics for sink failures/dead-letters. (`file-engine/internal/app/tasks/*`).
- Misc: DI wiring for Postgres tenant resolver/audit emitter, server instrumentation (gRPC unary/stream interceptors), new server upload HTTP handler with rate/concurrency guards, compose/docs updates for readiness probe, and backend controller changes to surface engine HTTP status codes through Laravel controllers. (various file updates in diff).

### Testing
- Ran unit/package tests for modified components: `cd file-engine && go test ./internal/server ./internal/observability ./internal/handlers ./internal/app/tasks -v` and they passed.
- Ran integration authz suite: `cd file-engine && go test -tags integration_authz ./tests/integration -run "TestCrossTenantPolicyCoverageWithTableDrivenCases|TestEngineBoundaryDeniesCrossTenantEvenWithBuggyUpstreamInputs" -v` and it passed.
- Executed focused operability tests: readiness handler unit tests and metrics snapshot tests were added and passed (see `file-engine/internal/server/readiness_test.go` and `file-engine/internal/observability/metrics_test.go`).
- Note: attempted `docker compose config` smoke-check but the `docker` CLI is not available in this environment; compose healthcheck wiring was updated to use `/readyz` in compose and docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994af83e134832dbb9051810cef3bef)