### PR TITLE
fix: Fix upload idempotency key replay scoping bug

### DIFF
--- a/file-engine/internal/services/upload_service.go
+++ b/file-engine/internal/services/upload_service.go
@@ -44,14 +44,20 @@ type UploadService struct {
 
 	mu          sync.RWMutex
 	metadata    map[string]UploadMetadata
-	idempotency map[string]UploadMetadata
+	idempotency map[string]idempotencyRecord
+}
+
+type idempotencyRecord struct {
+	Path       string
+	Meta       UploadMetadata
+	ErrMessage string
 }
 
 func NewUploadService(st storage.Storage, scanner ports.MalwareScanner, policy UploadPolicy) *UploadService {
 	if policy.RequestTimeout <= 0 {
 		policy.RequestTimeout = 10 * time.Second
 	}
-	return &UploadService{st: st, scanner: scanner, policy: policy, metadata: map[string]UploadMetadata{}, idempotency: map[string]UploadMetadata{}}
+	return &UploadService{st: st, scanner: scanner, policy: policy, metadata: map[string]UploadMetadata{}, idempotency: map[string]idempotencyRecord{}}
 }
 
 func (s *UploadService) Upload(ctx context.Context, targetPath string, content []byte) (UploadMetadata, error) {
@@ -59,19 +65,26 @@ func (s *UploadService) Upload(ctx context.Context, targetPath string, content [
 }
 
 func (s *UploadService) UploadStream(ctx context.Context, targetPath string, content io.Reader, idempotencyKey string) (UploadMetadata, error) {
-	if idempotencyKey != "" {
-		s.mu.RLock()
-		if m, ok := s.idempotency[idempotencyKey]; ok {
-			s.mu.RUnlock()
-			return m, nil
-		}
-		s.mu.RUnlock()
-	}
-
 	normalized, err := security.NormalizeTenantPath(targetPath)
 	if err != nil {
 		return UploadMetadata{}, err
 	}
+
+	if idempotencyKey != "" {
+		s.mu.RLock()
+		if r, ok := s.idempotency[idempotencyKey]; ok {
+			s.mu.RUnlock()
+			if r.Path != normalized {
+				return UploadMetadata{}, errors.New("idempotency key already used for a different target path")
+			}
+			if r.ErrMessage != "" {
+				return r.Meta, errors.New(r.ErrMessage)
+			}
+			return r.Meta, nil
+		}
+		s.mu.RUnlock()
+	}
+
 	tenantID := tenantFromPath(normalized)
 	if tenantID == "" {
 		return UploadMetadata{}, errors.New("invalid tenant path")
@@ -123,7 +136,7 @@ func (s *UploadService) UploadStream(ctx context.Context, targetPath string, con
 	}
 	if s.policy.RequireCleanScan && scanStatus != ports.MalwareStatusClean {
 		meta := UploadMetadata{TenantID: tenantID, Path: normalized, StagePath: stagePath, Size: cr.n, Checksum: checksum, ScanStatus: ports.MalwareStatusQuarantined, ScannedBy: scannedBy, CreatedAt: time.Now().UTC()}
-		s.storeMeta(meta, idempotencyKey)
+		s.storeMeta(meta, idempotencyKey, "malware scan gate blocked commit")
 		return meta, errors.New("malware scan gate blocked commit")
 	}
 
@@ -131,7 +144,7 @@ func (s *UploadService) UploadStream(ctx context.Context, targetPath string, con
 		return UploadMetadata{}, err
 	}
 	meta := UploadMetadata{TenantID: tenantID, Path: normalized, StagePath: stagePath, Size: cr.n, Checksum: checksum, ScanStatus: scanStatus, ScannedBy: scannedBy, CreatedAt: time.Now().UTC()}
-	s.storeMeta(meta, idempotencyKey)
+	s.storeMeta(meta, idempotencyKey, "")
 	return meta, nil
 }
 
@@ -170,12 +183,12 @@ func (s *UploadService) tenantUsage(tenantID string) (int64, int64) {
 	return total, count
 }
 
-func (s *UploadService) storeMeta(m UploadMetadata, idempotencyKey string) {
+func (s *UploadService) storeMeta(m UploadMetadata, idempotencyKey, errMessage string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.metadata[m.Path] = m
 	if idempotencyKey != "" {
-		s.idempotency[idempotencyKey] = m
+		s.idempotency[idempotencyKey] = idempotencyRecord{Path: m.Path, Meta: m, ErrMessage: errMessage}
 	}
 }
 

--- a/file-engine/internal/services/upload_service_test.go
+++ b/file-engine/internal/services/upload_service_test.go
@@ -89,3 +89,29 @@ func TestUploadServiceChecksumMismatch(t *testing.T) {
 		t.Fatalf("expected checksum mismatch")
 	}
 }
+
+func TestUploadServiceIdempotencyKeyCannotBeReusedAcrossTargets(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusClean}}, UploadPolicy{MaxObjectSizeBytes: 20, TenantQuotaBytes: 100, RequestTimeout: time.Second})
+
+	if _, err := svc.UploadStream(context.Background(), "/tenants/acme/docs/a.txt", bytes.NewReader([]byte("abc")), "same-key"); err != nil {
+		t.Fatalf("first upload: %v", err)
+	}
+
+	if _, err := svc.UploadStream(context.Background(), "/tenants/acme/docs/b.txt", bytes.NewReader([]byte("abc")), "same-key"); err == nil {
+		t.Fatalf("expected idempotency key target conflict")
+	}
+}
+
+func TestUploadServiceIdempotencyReplayPreservesFailure(t *testing.T) {
+	st := localstorage.New(t.TempDir())
+	svc := NewUploadService(st, scannerStub{result: ports.MalwareScanResult{Status: ports.MalwareStatusInfected, Engine: "stub"}}, UploadPolicy{MaxObjectSizeBytes: 20, TenantQuotaBytes: 100, RequestTimeout: time.Second, RequireCleanScan: true})
+
+	if _, err := svc.UploadStream(context.Background(), "/tenants/acme/docs/eicar.txt", bytes.NewReader([]byte("eicar")), "scan-key"); err == nil {
+		t.Fatalf("expected malware scan failure")
+	}
+
+	if _, err := svc.UploadStream(context.Background(), "/tenants/acme/docs/eicar.txt", bytes.NewReader([]byte("different")), "scan-key"); err == nil {
+		t.Fatalf("expected replay to return prior failure")
+	}
+}


### PR DESCRIPTION
### Motivation
- Fix a high-priority correctness bug in `UploadService.UploadStream` where repeated `idempotencyKey` lookups could return a cached success regardless of whether the new request targeted a different path or the original attempt had failed, which could silently drop uploads or return incorrect outcomes.

### Description
- Normalize the upload target path before idempotency lookup and reject replays when the stored record's path does not match the current normalized target.
- Replace `map[string]UploadMetadata` idempotency cache with `map[string]idempotencyRecord` that stores original `Path`, `Meta`, and an `ErrMessage` to preserve prior failure state.
- Persist failure state into idempotency records so replay returns the original error instead of a nil-success, and update `storeMeta` to accept an optional error message.
- Added unit tests and touched files: `file-engine/internal/services/upload_service.go` and `file-engine/internal/services/upload_service_test.go` to cover cross-target reuse and replay-of-failure cases.

### Testing
- Ran service unit tests with `cd file-engine && go test ./internal/services -v` and the package tests passed (all tests in `internal/services` succeeded).
- Ran baseline package tests with `cd file-engine && go test ./internal/config ./internal/logger ./internal/worker -v` and they reported no test files (no regressions observed).
- Ran the integration smoke test with `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v` and it passed, demonstrating integration-level behavior remained stable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952a598568832d8cea7126ad715d4d)