### PR TITLE
docs: align README claims with capability ledger baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 ![Trivy](https://github.com/<org>/<repo>/actions/workflows/trivy.yml/badge.svg)
 -->
 
-⚡️ **A governance-focused, multi-tenant file management platform written in Go an PHP** ⚡️ \
-Designed to operate directly on **real storage backends** (local/mounted SMB/NFS/SFTP, with adapter-based extensibility for S3/GCS). It centralizes access to shared storage with **RBAC + path-based ACL**, **async mutations**, baseline **task audit events**, and a **quarantine → scan → promote** upload pipeline (**target-state**).
+⚡️ **A governance-focused, multi-tenant file management platform written in Go and PHP** ⚡️ \
+Designed to operate directly on **real storage backends** (local/mounted SMB/NFS/SFTP, with adapter-based extensibility for S3/GCS). It centralizes access to shared storage with **RBAC + path-based ACL**, **async mutations**, baseline **task audit events**, and a baseline-validated **quarantine -> scan -> promote** guardrail flow (local semantics).
 
 </div>
 
@@ -28,8 +28,8 @@ Designed to operate directly on **real storage backends** (local/mounted SMB/NFS
 - **Multi-tenant:** tenant scope is resolved **server-side** (not trusted from JWT/client).
 - **AuthZ:** RBAC + path-based ACL with inheritance, **deny-by-default**, enforced at the File Engine boundary.
 - **Async mutations:** create (baseline) returns a `taskId`; move/upload are target-state; clients poll task status.
-- **Secure uploads:** quarantine -> scan -> promote workflow (**target-state, not fully baseline-validated**).
-- **Auditing:** persisted task status + basic task audit events in async folder flow baseline; dual-layer sink is target-state.
+- **Secure uploads:** staged quarantine write + scan-gated promote behavior are baseline-validated for local storage semantics; real scanner integration remains target-state.
+- **Auditing:** persisted task status + task audit events + append-only DB enforcement + external sink delivery are baseline-validated.
 - **Observability:** correlation IDs are propagated in baseline async flow logs/status; full OTEL pipeline is target-state.
 
 > [!Note]
@@ -150,7 +150,7 @@ This platform provides a centralized, permissioned interface that **controls and
 ### Write path (async)
 
 - Create folders (policy-enforced naming)
-- Upload files (two-step: initiate → complete) *(target-state)*
+- Upload storage guardrails (staged quarantine write + scan-gated promote) are baseline-validated in integration tests; public upload API surface remains target-state.
 - Move/rename/write operations *(as tasks; target-state)*
 
 ### Governance & security
@@ -158,7 +158,7 @@ This platform provides a centralized, permissioned interface that **controls and
 - JWT auth (Bearer)
 - RBAC + path-based ACL (inheritance)
 - Multi-tenant enforcement via **server-side tenant mapping**
-- Upload quarantine + malware scan gate before publish *(target-state)*
+- Upload quarantine + malware scan gate before publish (baseline guardrails validated with test scanner; real scanner integration is target-state)
 - Dual-layer audit (queryable + tamper-resistant sink) with baseline-validated external sink delivery adapters
 
 ---
@@ -175,7 +175,7 @@ This platform provides a centralized, permissioned interface that **controls and
 
 **Data Plane — Go File Engine + Worker:**
 
-- gRPC-first API + HTTP/JSON via gRPC-Gateway (baseline for CreateFolder + GetTaskStatus; uploads target-state)
+- gRPC-first API + HTTP/JSON via gRPC-Gateway (baseline for CreateFolder + GetTaskStatus; upload APIs remain target-state)
 - **Final authorization gate** (tenant membership + RBAC/ACL + safe-path execution)
 - Enqueues tasks; worker executes storage operations with least privilege
 
@@ -200,7 +200,7 @@ flowchart TB
   AV -->|verdict| W
 
   %% Audit
-  FE --> DB["(Postgres<br/>audit_events (append-only, target-state)<br/>ACL / mappings)"]
+  FE --> DB["(Postgres<br/>audit_events (append-only, baseline-validated)<br/>ACL / mappings)"]
   W --> DB
   DB --> SINK[Immutable Audit Sink<br/>SIEM / Loki / S3 WORM]
 ```
@@ -297,7 +297,7 @@ HTTP/JSON routes (baseline for CreateFolder + GetTaskStatus):
 - `POST /v1/folders` → `CreateFolder`
 - `GET /v1/tasks/{taskId}` → `GetTaskStatus`
 
-Upload HTTP routes remain target-state until the upload pipeline is implemented.
+Upload HTTP routes remain target-state until upload endpoints are promoted to baseline; storage-level upload guardrails are already baseline-validated via CL-025/CL-033.
 
 Task state model (canonical):
 
@@ -327,7 +327,7 @@ cd file-engine && go test ./internal/handlers -run "TestCreateFolderRequiresAuth
 
 ## Key flows
 
-**Target-state upload flow (not baseline-validated):**
+**Target-state upload API flow (storage guardrails are baseline-validated; endpoint contract is not yet baseline-promoted):**
 
 ```mermaid
 sequenceDiagram
@@ -387,7 +387,7 @@ Secure-by-default controls:
 - Deny-by-default authorization at File Engine
 - Tenant scope from server-side mapping (not JWT)
 - Strict path normalization + traversal rejection
-- Quarantine → scan → promote gating *(target-state)*
+- Quarantine → scan → promote gating (baseline guardrails validated in local integration tests; real scanner integration target-state)
 - Redaction policy: never log tokens or pre-signed URLs
 
 Known gaps / planned hardening (examples):
@@ -402,10 +402,10 @@ Known gaps / planned hardening (examples):
 
 ## Auditing
 
-**Dual-layer audit (target-state vision):**
+**Dual-layer audit:**
 
-- **Primary (queryable)**: Postgres `audit_events` table (append-only, target-state)
-- **Secondary (tamper-resistant)**: external sink (SIEM / Loki / S3 WORM) with retries + DLQ + lag metric (`CL-035`)
+- **Primary (queryable)**: Postgres `audit_events` table (append-only enforcement baseline-validated in `CL-032`)
+- **Secondary (tamper-resistant)**: external sink (SIEM / Loki / S3 WORM) with retries + DLQ + lag metric baseline-validated in `CL-035`
 
 **Baseline audit behavior:**
 
@@ -464,7 +464,7 @@ cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v
 
 ### 3) Optional: local File Engine run (scaffold-level, for debugging)
 
-This brings up Redis/Postgres in Docker and runs the API/worker locally. REST endpoints are baseline for `CreateFolder` + `GetTaskStatus`; uploads remain target-state. Treat this path as a debug path beyond baseline behavior.
+This brings up Redis/Postgres in Docker and runs the API/worker locally. REST endpoints are baseline for `CreateFolder` + `GetTaskStatus`; upload endpoints remain target-state even though storage-level upload guardrails are baseline-validated in tests. Treat this path as a debug path beyond baseline behavior.
 
 ```bash
 cd file-engine

--- a/docs/roadmap-ledger-gap-analysis.md
+++ b/docs/roadmap-ledger-gap-analysis.md
@@ -1,0 +1,48 @@
+# Roadmap vs Capability Ledger Gap Analysis
+
+**Date:** 2026-02-19  
+**Source-of-truth rule applied:** `docs/capability-ledger.md` takes precedence over roadmap intent and narrative docs.
+
+## Comparison summary
+
+| Roadmap milestone | Roadmap intent | Ledger-backed status | Gap status |
+| :-- | :-- | :-- | :-- |
+| Milestone 0 — Baseline Integrity | Baseline CI + ledger runnable checks + doc drift + README maturity labeling | Baseline CI claim gate exists (`CL-034`), doc drift check is baseline (`CL-011`), and README references claim-mapped baseline/target-state framing | **Largely implemented** |
+| Milestone 1 — Read Path Baseline | Read/list endpoint + authz rejection + docs/demo evidence | Read/list/authz checks are baseline (`CL-012`) | **Implemented** |
+| Milestone 2 — Write Path Baseline | Async create-folder + status persistence + audit + guardrails | Async folder flow/status/audit are baseline (`CL-003`, `CL-004`, `CL-005`), guardrails are baseline (`CL-017`) | **Implemented** |
+| Milestone 3 — Upload Pipeline | Quarantine/scan/promote + scan metrics/logging | Upload staging/promote and malware gate are baseline (`CL-033` and upload tests referenced in domain table) | **Mostly implemented; scanner realism still open** |
+| Milestone 4 — Observability & Audit Sink | OTEL traces + external audit sink | External sink adapters + DLQ/lag metric baseline (`CL-035`); OTEL export still listed as target-state | **Partially implemented** |
+| Milestone 5 — Governance Hardening | Doc ownership metadata + quarterly alignment cadence + architecture conformance checks in CI | Conformance checks are evidenced (`CL-001`, `CL-016`, `CL-011`, `CL-034`), quarterly alignment review doc exists, but explicit doc ownership metadata standard is not clearly ledger-tracked | **Partially implemented** |
+
+## What is still not implemented (or not promoted as baseline)
+
+Based on strict ledger-vs-roadmap comparison, these roadmap objectives remain open:
+
+1. **Full OpenTelemetry export pipeline (Milestone 4).**
+   - The roadmap requires OTEL traces for API + worker.
+   - Ledger still marks full OTEL backend export/alerting as **target-state**.
+
+2. **Real scanner integration for upload security pipeline (Milestone 3 completion depth).**
+   - Ledger confirms malware gate behavior and staged promotion semantics.
+   - Ledger target-state explicitly keeps **real scanner integration** out of baseline.
+
+3. **Doc ownership metadata as a formal hardening control (Milestone 5).**
+   - Roadmap calls this out directly.
+   - The ledger does not currently expose a dedicated baseline claim validating ownership metadata coverage on key docs.
+
+## Items that appear implemented and should be treated as done
+
+These roadmap expectations have concrete baseline evidence and are effectively delivered:
+
+- Baseline integrity controls (claim-gated validations + doc drift check).
+- Read/list authz baseline.
+- Async write-path baseline for create-folder, status lifecycle, and audit events.
+- External audit sink with retries/DLQ/lag metric.
+- CI-oriented conformance checks for proto sync/artifacts and baseline verification scripts.
+
+## Suggested next promotions (if you want roadmap closure)
+
+1. Add a ledger claim + deterministic validation command for **OTEL export** wiring (even minimal trace assertion).
+2. Add a ledger claim for **real scanner integration** (non-stub path) with runnable integration evidence.
+3. Add a governance claim for **doc ownership metadata coverage** with a script-based check over required docs.
+


### PR DESCRIPTION
### Motivation
- The README described several capabilities as target-state that the capability ledger now marks as baseline-validated, causing doc drift between top-level messaging and the canonical ledger.

### Description
- Updated README copy to align with `docs/capability-ledger.md`, clarifying that storage-level upload guardrails (staged quarantine, scan-gated promote) and audit enforcement (append-only DB + external sink delivery) are baseline-validated while the public upload API surface and real scanner integration remain target-state.
- Adjusted TL;DR, write-path, architecture, security/audit, and quickstart sections and fixed a small typo in the project header ("Go and PHP").

### Testing
- Ran the repository doc drift check via `./scripts/doc-drift-check.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971fdd42d4832d90f8bfdfbc57b9f3)