### PR TITLE
fix: potential fix for code scanning alert no. 10: Uncontrolled data used in the path expression

### DIFF
--- a/file-engine/internal/adapters/storage/local/local_storage.go
+++ b/file-engine/internal/adapters/storage/local/local_storage.go
@@ -27,7 +27,26 @@ func New(base string) *LocalStorage {
 
 func (l *LocalStorage) full(p string) string {
 	clean := normalizePath(p)
-	return filepath.Join(l.base, clean)
+	joined := filepath.Join(l.base, clean)
+
+	// Ensure that the resolved path stays within the configured base directory.
+	baseAbs, errBase := filepath.Abs(l.base)
+	fullAbs, errFull := filepath.Abs(joined)
+	if errBase != nil || errFull != nil {
+		return l.base
+	}
+
+	baseWithSep := baseAbs
+	if !strings.HasSuffix(baseWithSep, string(filepath.Separator)) {
+		baseWithSep += string(filepath.Separator)
+	}
+
+	if fullAbs == baseAbs || strings.HasPrefix(fullAbs, baseWithSep) {
+		return fullAbs
+	}
+
+	// If the path would escape the base directory, fall back to the base itself.
+	return baseAbs
 }
 
 func normalizePath(p string) string {


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/file-server-management/security/code-scanning/10](https://github.com/agslima/file-server-management/security/code-scanning/10)

In general, to fix uncontrolled path usage you want the storage layer—the point where paths are turned into real filesystem paths—to enforce that any caller-provided path resolves within a configured “safe” base directory. This is usually done by joining the base with the requested path, resolving to an absolute path, and then ensuring that the resolved path has the safe base as its prefix. This protects even if upstream components forget or change their own validation.

For this codebase, the best fix with minimal functional change is to harden `LocalStorage.full` in `file-engine/internal/adapters/storage/local/local_storage.go`:

1. Keep the existing logical path normalization (`normalizePath`) so callers can continue to pass the same logical paths.
2. After `normalizePath`, use `filepath.Join` as before to get a candidate path.
3. Resolve both `l.base` and the candidate path to absolute paths with `filepath.Abs`.
4. Ensure that the resulting absolute path is contained within the absolute base directory:
   - Normalize the base to include a trailing path separator (so `/var/data` doesn’t match `/var/database`).
   - Check that either the absolute file path is exactly the base, or has the base-with-separator as a prefix.
5. If the path is invalid (error resolving, or not under base), return `l.base` as a safe fallback instead of the joined path. Returning `l.base` is safe for read/write/delete/list operations from a security perspective (it just prevents traversal above base), and doesn’t require propagating errors through all callers. The semantic change is limited: attempts to escape the base will now operate on the base directory itself rather than on unintended paths.

This change is localized entirely to `full` (and optionally `New` if we want to pre-normalize `base`, but we can avoid that to minimize edits). It uses only the standard library functions already imported (`filepath`), so no new imports or dependencies are needed. Callers of `LocalStorage` (`CreateFolder`, `AtomicWrite`, `Move`, `Delete`, `Exists`, `List`, `Open`) will automatically benefit from the stronger containment guarantee without any further modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
