### PR TITLE
fix: add ripgrep fallback in scripts/check-owners-governance.sh

### DIFF
--- a/scripts/check-owners-governance.sh
+++ b/scripts/check-owners-governance.sh
@@ -9,10 +9,21 @@ required_refs=(
 
 [[ -f .github/OWNERS ]] || { echo ".github/OWNERS missing" >&2; exit 1; }
 
+contains_literal() {
+  local value="$1"
+  local file="$2"
+
+  if command -v rg >/dev/null 2>&1; then
+    rg -Fq "$value" "$file"
+  else
+    grep -Fq "$value" "$file"
+  fi
+}
+
 for ref in "${required_refs[@]}"; do
   file="${ref%%:*}"
   needle="${ref##*:}"
-  if ! rg -q "$needle" "$file"; then
+  if ! contains_literal "$needle" "$file"; then
     echo "$file: missing reference to $needle" >&2
     exit 1
   fi


### PR DESCRIPTION
### Motivation
- Prevent CI failures when `rg` (ripgrep) is not installed by falling back to `grep` for OWNERS reference checks.

### Description
- Added a `contains_literal()` helper that uses `rg -Fq` when present and falls back to `grep -Fq`, and replaced the direct `rg -q` call with this helper in `scripts/check-owners-governance.sh`.

### Testing
- Executed `./scripts/check-owners-governance.sh` and `PATH=/bin ./scripts/check-owners-governance.sh` to simulate environments with and without `rg`, and both runs succeeded returning `OWNERS_GOVERNANCE_REFERENCE_OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8955b22c832d94c8949277eee955)