### PR TITLE
fix: CI docker gating and authz detection; normalize admin move/restore paths

### DIFF
--- a/.github/workflows/ci-pr-security-scan.yaml
+++ b/.github/workflows/ci-pr-security-scan.yaml
@@ -75,8 +75,14 @@ jobs:
           fi
 
           # Normalize docker file list -> JSON array
-          docker_json="$(printf '%s' "$DOCKER_CHANGED_FILES" \
-            | jq -Rsc 'split("\n") | map(select(length > 0))')"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            docker_json="$(find . -type f \( -name 'Dockerfile*' -o -name 'docker-compose.yml' \) \
+              | sed 's|^\./||' \
+              | jq -Rsc 'split("\n") | map(select(length > 0))')"
+          else
+            docker_json="$(printf '%s' "$DOCKER_CHANGED_FILES" \
+              | jq -Rsc 'split("\n") | map(select(length > 0))')"
+          fi
 
           echo "docker_files_json=$docker_json" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
               - '.github/workflows/ci.yml'
             authz:
               - 'file-engine/internal/authz/**'
+              - 'file-engine/tests/integration/**authz**'
             monitoring:
               - 'monitoring/**'
               

--- a/file-engine/internal/server/admin_http.go
+++ b/file-engine/internal/server/admin_http.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/example/file-engine/internal/auth"
+	"github.com/example/file-engine/internal/security"
 )
 
 func (h *HTTPServer) requireAdmin(w http.ResponseWriter, r *http.Request) (auth.AuthContext, bool) {
@@ -349,10 +350,28 @@ func (h *HTTPServer) handleObjectMove(w http.ResponseWriter, r *http.Request) {
 		SourcePath      string `json:"source_path"`
 		DestinationPath string `json:"destination_path"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.SourcePath) == "" || strings.TrimSpace(req.DestinationPath) == "" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}
+	req.SourcePath = strings.TrimSpace(req.SourcePath)
+	req.DestinationPath = strings.TrimSpace(req.DestinationPath)
+	if req.SourcePath == "" || req.DestinationPath == "" {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	normalizedSourcePath, err := security.NormalizeTenantPath(req.SourcePath)
+	if err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	normalizedDestinationPath, err := security.NormalizeTenantPath(req.DestinationPath)
+	if err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	req.SourcePath = normalizedSourcePath
+	req.DestinationPath = normalizedDestinationPath
 	meta, err := h.Uploads.MoveObject(r.Context(), authCtx.EffectiveActorID(), req.SourcePath, req.DestinationPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)
@@ -379,10 +398,21 @@ func (h *HTTPServer) handleQuarantineRestore(w http.ResponseWriter, r *http.Requ
 		Path           string `json:"path"`
 		ForceReprocess bool   `json:"force_reprocess"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.Path) == "" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}
+	req.Path = strings.TrimSpace(req.Path)
+	if req.Path == "" {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	normalizedPath, err := security.NormalizeTenantPath(req.Path)
+	if err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	req.Path = normalizedPath
 	meta, err := h.Uploads.RestoreQuarantinedObject(r.Context(), authCtx.EffectiveActorID(), req.Path, req.ForceReprocess)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusConflict)


### PR DESCRIPTION
### Motivation
- Ensure manual `workflow_dispatch` security scans do not skip Docker scanning by emitting the same `docker_files_json` output the gate expects. 
- Ensure authz reviewer gates trigger when integration tests that affect authz are edited. 
- Prevent service-layer move/restore calls from receiving untrimmed or unnormalized paths from the admin HTTP handlers.

### Description
- `.github/workflows/ci-pr-security-scan.yaml`: when `github.event_name == workflow_dispatch` compute `docker_files_json` by discovering repository `Dockerfile*` and `docker-compose.yml` paths and emit it to `GITHUB_OUTPUT` alongside `docker=true`, preserving the existing `docker_files_json` name and format.
- `.github/workflows/ci.yml`: extend the `authz` changed-files filter to include `file-engine/tests/integration/**authz**` in addition to `file-engine/internal/authz/**` so integration-test edits are detected by the authz gate.
- `file-engine/internal/server/admin_http.go`: trim and validate request path fields and apply `security.NormalizeTenantPath(...)` before calling `Uploads.MoveObject` and `Uploads.RestoreQuarantinedObject`, and add the `security` import to use the normalization helper.

### Testing
- Ran unit baseline commands: `cd file-engine && go test ./internal/config ./internal/logger ./internal/worker -v`, which completed successfully. 
- Ran integration verification: `cd file-engine && go test ./tests/integration -run TestAsyncCreateFolderFlow -v`, which passed (`TestAsyncCreateFolderFlow` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cce016ffc832d830368ec9b0db5c8)