### PR TITLE
chore: Enhance workflow self-test with concurrency and actionlint

### DIFF
--- a/.github/workflows/workflow-selftest.yaml
+++ b/.github/workflows/workflow-selftest.yaml
@@ -2,32 +2,26 @@ name: Workflow Self-Test
 
 on:
   workflow_dispatch:
-
 permissions:
   contents: read
-
+concurrency:
+  group: workflow-selftest-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   change-detection-test:
     name: Test change detection logic (unit)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-
       - name: Run test
         run: python tests/test_ci_pr_security_scan_change_detection.py
 
-  actionlint:
-    name: Lint workflows (actionlint)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Check workflow files
-        uses: docker://rhysd/actionlint:latest
-        with:
-          args: -color
+  workflow-test:
+    name: Check workflows (actionlint + provenance)
+    permissions:
+      contents: read
+    uses: agslima/app-stayhealthy-pipeline/.github/workflows/workflow-selftest.yml@main


### PR DESCRIPTION
Added concurrency settings and updated actionlint job to use a reusable workflow.

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->
